### PR TITLE
Fix missing "use" in `PatternLab\Annotations`

### DIFF
--- a/src/PatternLab/Annotations.php
+++ b/src/PatternLab/Annotations.php
@@ -15,6 +15,7 @@ namespace PatternLab;
 use \PatternLab\Config;
 use \PatternLab\Console;
 use \PatternLab\Dispatcher;
+use \PatternLab\Parsers\Documentation;
 use \Symfony\Component\Yaml\Exception\ParseException;
 use \Symfony\Component\Yaml\Yaml;
 use \PatternLab\Timer;


### PR DESCRIPTION
- `PatternLab\Parsers\Documentation` needs a `use`
