### PR TITLE
Fix error on pattern path resolution in Windows caused by mixed direc…

### DIFF
--- a/src/PatternLab/PatternData.php
+++ b/src/PatternLab/PatternData.php
@@ -128,8 +128,8 @@ class PatternData {
 			$isDir    = $object->isDir();
 			$isFile   = $object->isFile();
 			
-			$path     = str_replace($patternSourceDir."/","",$object->getPath());
-			$pathName = str_replace($patternSourceDir."/","",$object->getPathname());
+			$path     = str_replace($patternSourceDir.DIRECTORY_SEPARATOR,"",$object->getPath());
+			$pathName = str_replace($patternSourceDir.DIRECTORY_SEPARATOR,"",$object->getPathname());
 			$name     = $object->getFilename();
 			$depth    = substr_count($pathName,DIRECTORY_SEPARATOR);
 			


### PR DESCRIPTION
Fix error on pattern path resolution in Windows caused by mixed directory separators

For a description of the problem:
https://github.com/pattern-lab/edition-php-twig-standard/issues/6