### PR TITLE
BUGFIX: There was a mixup in array keys when storing the pattern suboptions

### DIFF
--- a/src/PatternLab/PatternData.php
+++ b/src/PatternLab/PatternData.php
@@ -478,7 +478,7 @@ class PatternData {
 	
 		if (isset(self::$store[$patternStoreKey]) && isset(self::$store[$patternStoreKey][$optionName]) && isset(self::$store[$patternStoreKey][$optionName][$patternSubStoreKey])) {
 			
-			self::$store[$patternStoreKey][$optionName][$patternLineageKey][$optionSubName] = $optionSubValue;
+			self::$store[$patternStoreKey][$optionName][$patternSubStoreKey][$optionSubName] = $optionSubValue;
 			return true;
 			
 		}


### PR DESCRIPTION
BUGFIX: There was a mixup in array keys when storing the pattern subo…
I fixed the array key.