### PR TITLE
BUGFIX: lineage url fix

### DIFF
--- a/src/PatternLab/PatternData/Helpers/LineageHelper.php
+++ b/src/PatternLab/PatternData/Helpers/LineageHelper.php
@@ -53,9 +53,10 @@ class LineageHelper extends \PatternLab\PatternData\Helper {
 					foreach ($foundLineages as $lineage) {
 						
 						if (PatternData::getOption($lineage)) {
-							
-							$patternLineages[] = array("lineagePattern" => $lineage,
-													   "lineagePath"    => "../../patterns/".$patternStoreData["pathDash"]."/".$patternStoreData["pathDash"].".html");
+
+              $path = PatternData::getPatternOption($lineage, "pathDash");
+              $patternLineages[] = array("lineagePattern" => $lineage,
+              			"lineagePath"    => "../../patterns/".$path."/".$path.".html");
 							
 						} else {
 							


### PR DESCRIPTION
I am using the twig version of pattern lab and I've found a bug where the lineage links are wrong when viewing them inside of the code viewer.

I believe the incorrect code is [inside of lineageHelper.php]:

```
if (PatternData::getOption($lineage)) {

  $patternLineages[] = array("lineagePattern" => $lineage,
                 "lineagePath"    => "../../patterns/".$patternStoreData["pathDash"]."/".$patternStoreData["pathDash"].".html");
```

in this case, `$patternStoreData["pathDash"]` is actually the path to the _current_ pattern, not the lineage. The below change gives the correct path to the lineage pattern.

**note**: even though this gets the link correct, it hangs when trying to click it. This may be a twig-version issue though...
