### PR TITLE
Fix bug on pattern engine install in Windows caused by mixed directory separators

### DIFF
--- a/src/PatternLab/InstallerUtil.php
+++ b/src/PatternLab/InstallerUtil.php
@@ -655,7 +655,7 @@ class InstallerUtil {
 		foreach ($finder as $file) {
 			
 			/// create the name
-			$dirs              = explode("/",$file->getPath());
+			$dirs              = explode(DIRECTORY_SEPARATOR,$file->getPath());
 			$patternEngineName = "\\".$dirs[count($dirs)-3]."\\".$dirs[count($dirs)-2]."\\".$dirs[count($dirs)-1]."\\".str_replace(".php","",$file->getFilename());
 			
 			// check what we should do with the pattern engine info


### PR DESCRIPTION
The previous version put faulty path in patternengines.json on a pattern
engine install. This fixes that.