### PR TITLE
Don't require very specific dependencies of upstream libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,14 +31,14 @@
 	"prefer-stable": true,
 	"require": {
 		"php": ">=5.3.6",
-		"michelf/php-markdown": "1.5.0",
-		"seld/jsonlint": "1.3.1",
-		"symfony/event-dispatcher": "2.6.4",
-		"symfony/filesystem": "2.6.4",
-		"symfony/finder": "2.6.4",
-		"symfony/yaml": "2.6.4",
-		"kevinlebrun/colors.php": "0.4.1",
+		"michelf/php-markdown": "~1.5",
+		"seld/jsonlint": "~1.3",
+		"symfony/event-dispatcher": "~2.6",
+		"symfony/filesystem": "~2.6.4",
+		"symfony/finder": "~2.6",
+		"symfony/yaml": "~2.6",
+		"kevinlebrun/colors.php": "~0.4.1",
 		"pattern-lab/unified-asset-installer": "~0.5",
-		"alchemy/zippy": "0.2.1"
+		"alchemy/zippy": "~0.2.1"
 	}
 }


### PR DESCRIPTION
I'd like to be able to integrate Patternlab with another code base, but the to-the-patch-version dependencies in composer.json totally break that.

There's a question about the same issue on the commit at 6bb7c7b393c8e65635ca1bea1cd309f302aed5d4 - I've yet to find any answer as to why this was done in the first place.