### PR TITLE
Fix for MD files with no `title` in yaml front matter

### DIFF
--- a/src/PatternLab/PatternData/Rules/DocumentationRule.php
+++ b/src/PatternLab/PatternData/Rules/DocumentationRule.php
@@ -81,11 +81,14 @@ class DocumentationRule extends \PatternLab\PatternData\Rule {
 			$patternStoreKey  = ($patternSubtypeDoc) ? $docPartial."-plsubtype" : $docPartial;
 			
 			$patternStoreData = array("category"   => $category,
-									  "nameClean"  => $title,
 									  "desc"       => $markdown,
 									  "descExists" => true,
 									  "meta"       => $yaml,
 									  "full"       => $doc);
+
+			if (isset($title)) {
+				$patternStoreData["nameClean"] = $title;
+			}
 			
 			// if the pattern data store already exists make sure this data overwrites it
 			$patternStoreData = (PatternData::checkOption($patternStoreKey)) ? array_replace_recursive(PatternData::getOption($patternStoreKey),$patternStoreData) : $patternStoreData;


### PR DESCRIPTION
When pattern description markdown files have this PL compiles fine with no error:

```
---
title: Some info
---
My *Awesome* Markdown description of my amazing Pattern
```

When they lack the Yaml Front Matter with the `title` variable, PL does compile but gives this error:

```
PHP Notice:  Undefined variable: title in /Users/Evan/dev/contrib/pl/patternlab-php-core/src/PatternLab/PatternData/Rules/DocumentationRule.php on line 84
PHP Stack trace:
PHP   1. {main}() /Users/Evan/dev/p2/pinterest/pl/pattern-lab/core/console:0
PHP   2. PatternLab\Console::run() /Users/Evan/dev/p2/pinterest/pl/pattern-lab/core/console:46
PHP   3. PatternLab\Console\Commands\GenerateCommand->run() /Users/Evan/dev/contrib/pl/patternlab-php-core/src/PatternLab/Console.php:83
PHP   4. PatternLab\Generator->generate() /Users/Evan/dev/contrib/pl/patternlab-php-core/src/PatternLab/Console/Commands/GenerateCommand.php:41
PHP   5. PatternLab\PatternData::gather() /Users/Evan/dev/contrib/pl/patternlab-php-core/src/PatternLab/Generator.php:69
PHP   6. PatternLab\PatternData\Rules\DocumentationRule->run() /Users/Evan/dev/contrib/pl/patternlab-php-core/src/PatternLab/PatternData.php:139
configuring pattern lab...

Notice: Undefined variable: title in /Users/Evan/dev/contrib/pl/patternlab-php-core/src/PatternLab/PatternData/Rules/DocumentationRule.php on line 84

Call Stack:
    0.2049     241016   1. {main}() /Users/Evan/dev/p2/pinterest/pl/pattern-lab/core/console:0
    0.2303    1162328   2. PatternLab\Console::run() /Users/Evan/dev/p2/pinterest/pl/pattern-lab/core/console:46
    0.2356    1317424   3. PatternLab\Console\Commands\GenerateCommand->run() /Users/Evan/dev/contrib/pl/patternlab-php-core/src/PatternLab/Console.php:83
    0.2748    3254016   4. PatternLab\Generator->generate() /Users/Evan/dev/contrib/pl/patternlab-php-core/src/PatternLab/Console/Commands/GenerateCommand.php:41
    0.2791    3635352   5. PatternLab\PatternData::gather() /Users/Evan/dev/contrib/pl/patternlab-php-core/src/PatternLab/Generator.php:69
    0.2851    3915976   6. PatternLab\PatternData\Rules\DocumentationRule->run() /Users/Evan/dev/contrib/pl/patternlab-php-core/src/PatternLab/PatternData.php:139

your site has been generated...
site generation took 0.25827598571777 seconds and used 9MB of memory...
let me take this moment to compliment you on your fashion sense, particularly your slippers...

```

This PR allows markdown files to exist with no yaml front matter at all; which is awesome!