### PR TITLE
adding http:// prefix to url so it is clickable

### DIFF
--- a/src/PatternLab/Console/Commands/ServerCommand.php
+++ b/src/PatternLab/Console/Commands/ServerCommand.php
@@ -49,7 +49,7 @@ class ServerCommand extends Command {
 			$host = $port ? $host.":".$port : $host.":8080";
 			
 			// start-up the server with the router
-			Console::writeInfo("server started on ".$host.". use ctrl+c to exit...");
+			Console::writeInfo("server started on http://".$host.". use ctrl+c to exit...");
 			passthru("cd ".$publicDir." && ".$_SERVER["_"]." -S ".$host." ".$coreDir."/server/router.php");
 			
 		}

--- a/src/PatternLab/Console/Commands/ServerCommand.php
+++ b/src/PatternLab/Console/Commands/ServerCommand.php
@@ -49,7 +49,7 @@ class ServerCommand extends Command {
 			$host = $port ? $host.":".$port : $host.":8080";
 			
 			// start-up the server with the router
-			Console::writeInfo("server started on http://".$host.". use ctrl+c to exit...");
+			Console::writeInfo("server started on http://".$host." - use ctrl+c to exit...");
 			passthru("cd ".$publicDir." && ".$_SERVER["_"]." -S ".$host." ".$coreDir."/server/router.php");
 			
 		}


### PR DESCRIPTION
By doing this, `localhost:8080` becomes `http://localhost:8080` - so you can select & copy it to open .... or if you're running iTerm v3 you can hold cmd and then click it :)