### PR TITLE
Fixing Yaml Pseudo Pattern Parse Error

### DIFF
--- a/src/PatternLab/PatternData/Rules/PseudoPatternRule.php
+++ b/src/PatternLab/PatternData/Rules/PseudoPatternRule.php
@@ -129,7 +129,7 @@ class PseudoPatternRule extends \PatternLab\PatternData\Rule {
 			} else {
 
 				try {
-					$patternDataBase = YAML::parse($file);
+					$patternDataBase = YAML::parse($data);
 				} catch (ParseException $e) {
 					printf("unable to parse ".$pathNameClean.": %s..\n", $e->getMessage());
 				}


### PR DESCRIPTION
When using yaml for Pseudo Patterns (`pattern~variant.yml`); I was getting an error saying that `$file` didn't exist. You can see a couple line up the JSON parsing is `json_decode($data,true)`, so I changed `$file` to `$data` and everything worked. (Xdebug in PhpStorm also showed `$data` containing a string of yaml data unparsed).