### PR TITLE
Fix failure to reset variables in loop

### DIFF
--- a/src/PatternLab/Builder.php
+++ b/src/PatternLab/Builder.php
@@ -391,8 +391,8 @@ class Builder {
 					$patternData["patternPartial"] = "viewall-".$patternStoreData["nameDash"]."-all";
 					
 					// add the pattern lab specific mark-up
-					$partials["patternLabHead"] = $stringLoader->render(array("string" => $htmlHead, "data" => array("cacheBuster" => $partials["cacheBuster"])));
-					$partials["patternLabFoot"] = $stringLoader->render(array("string" => $htmlFoot, "data" => array("cacheBuster" => $partials["cacheBuster"], "patternData" => json_encode($patternData))));
+					$globalData["patternLabHead"] = $stringLoader->render(array("string" => $htmlHead, "data" => array("cacheBuster" => $partials["cacheBuster"])));
+					$globalData["patternLabFoot"] = $stringLoader->render(array("string" => $htmlFoot, "data" => array("cacheBuster" => $partials["cacheBuster"], "patternData" => json_encode($patternData))));
 					
 					// render the parts and join them
 					$header      = $patternLoader->render(array("pattern" => $patternHead, "data" => $globalData));


### PR DESCRIPTION
When generating `patternLabHead` and `patternLabFoot` for `patternType` 
partials, the variables that hold the rendered strings were named incorrectly, 
which caused the header and footer to contain the rendered strings of the last 
rendered `patternSubType` (due to data hanging around from the last loop), or 
nothing if it was the first `patternType`.

This cause two bugs for us. 1) The styleguide.min.css was missing on our Atoms > View All, and 2) Clicking on Molecules > View All would actually load Atoms > Images instead.