### PR TITLE
Fix parse error in InstallerUtil.php

### DIFF
--- a/src/PatternLab/InstallerUtil.php
+++ b/src/PatternLab/InstallerUtil.php
@@ -350,7 +350,7 @@ class InstallerUtil {
 				foreach ($finder as $file) {
 					
 					$ext      = $file->getExtension();
-					$pathName = $file->getPathname());
+					$pathName = $file->getPathname();
 					
 					if ($ext == "css") {
 						$componentTypes["stylesheets"][] = str_replace(DIRECTORY_SEPARATOR,"/",str_replace($sourceBase.$source,$destination,$pathName));


### PR DESCRIPTION
I tried to switch to the dev branch since the fix in https://github.com/pattern-lab/patternlab-php-core/pull/86 is already there, but ran into a parse error.

> Parse error: syntax error, unexpected ')' in vendor/pattern-lab/core/src/PatternLab/InstallerUtil.php on line 353
