### PR TITLE
Allowing idle timeout duration to be controlled in the config

### DIFF
--- a/config/config.yml.default
+++ b/config/config.yml.default
@@ -43,3 +43,6 @@ defaultPattern: "all"
 
 # show pattern info by default on the "view all" views
 defaultShowPatternInfo: false
+
+# set idle timeout duration. defaults to 600s if no value is specified
+idleTimeoutDuration: '600'

--- a/src/PatternLab/Console/Commands/WatchCommand.php
+++ b/src/PatternLab/Console/Commands/WatchCommand.php
@@ -65,10 +65,12 @@ class WatchCommand extends Command {
 				
 			} else {
 				
+				$idleTimeoutDuration = Config::getOption("idleTimeoutDuration") ? Config::getOption("idleTimeoutDuration") : 600;
+
 				// a vanilla --watch command needs to have a --no-procs version built
 				// so we don't get caught in while() loops. re-request the console command
 				$commands     = array();
-				$commands[]   = array("command" => $this->build()." --no-procs", "timeout" => null, "idle" => 600);
+				$commands[]   = array("command" => $this->build()." --no-procs", "timeout" => null, "idle" => $idleTimeoutDuration);
 				
 				Console::writeInfo("spawning the watch process...");
 				


### PR DESCRIPTION
Some changes to allow for the idle timeout duration to be controlled via the config file. If no value is specified it will default to 600s (10mins)
