### PR TITLE
Ensure YAML data files can use yml extension too

### DIFF
--- a/src/PatternLab/Data.php
+++ b/src/PatternLab/Data.php
@@ -125,7 +125,7 @@ class Data {
 			$pathName      = $file->getPathname();
 			$pathNameClean = str_replace($sourceDir."/","",$pathName);
 
-			if (!$hidden && (($ext == "json") || ($ext == "yaml"))) {
+			if (!$hidden && (($ext == "json") || ($ext == "yaml") || ($ext == "yml"))) {
 
 				if ($isListItems === false) {
 
@@ -137,7 +137,7 @@ class Data {
 							JSON::lastErrorMsg($pathNameClean,$jsonErrorMessage,$data);
 						}
 
-					} else if ($ext == "yaml") {
+					} else if (($ext == "yaml") || ($ext == "yml")) {
 
 						$file = file_get_contents($pathName);
 


### PR DESCRIPTION
Currently you can only use `.yaml` as an extension on global data files; this allows the use of `.yml` too. This is important as both are widely used, even the Pattern Lab config file is using `.yml`.
