### PR TITLE
BUGFIX: Pattern state evaluation

### DIFF
--- a/src/PatternLab/Builder.php
+++ b/src/PatternLab/Builder.php
@@ -29,77 +29,77 @@ use \PatternLab\Timer;
 use \Symfony\Component\Finder\Finder;
 
 class Builder {
-
+	
 	/**
 	* When initializing the Builder class make sure the template helper is set-up
 	*/
 	public function __construct() {
-
+		
 		// set-up the pattern engine
 		PatternEngine::init();
-
+		
 		// set-up the various attributes for rendering templates
 		Template::init();
-
+		
 	}
-
+	
 	/**
 	* Generates the annotations js file
 	*/
 	protected function generateAnnotations() {
-
+		
 		// set-up the dispatcher
 		$dispatcherInstance = Dispatcher::getInstance();
-
+		
 		// note the start of the operation
 		$dispatcherInstance->dispatch("builder.generateAnnotationsStart");
-
+		
 		// default var
 		$publicDir = Config::getOption("publicDir");
-
+		
 		// encode the content so it can be written out
 		$json      = json_encode(Annotations::get());
-
+		
 		// make sure annotations/ exists
 		if (!is_dir($publicDir."/annotations")) {
 			mkdir($publicDir."/annotations");
 		}
-
+		
 		// write out the new annotations.js file
 		file_put_contents($publicDir."/annotations/annotations.js","var comments = ".$json.";");
-
+		
 		// note the end of the operation
 		$dispatcherInstance->dispatch("builder.generateAnnotationsEnd");
-
+		
 	}
-
+	
 	/**
 	* Generates the data that powers the index page
 	*/
 	protected function generateIndex() {
-
+		
 		// bomb if missing index.html
 		if (!file_exists(Config::getOption("publicDir")."/index.html")) {
 			$index = Console::getHumanReadablePath(Config::getOption("publicDir")).DIRECTORY_SEPARATOR."index.html";
 			Console::writeError("<path>".$index."</path> is missing. grab a copy from your StyleguideKit...");
 		}
-
+		
 		// set-up the dispatcher
 		$dispatcherInstance = Dispatcher::getInstance();
-
+		
 		// note the start of the operation
 		$dispatcherInstance->dispatch("builder.generateIndexStart");
-
+		
 		// default var
 		$dataDir = Config::getOption("publicDir")."/styleguide/data";
-
+		
 		// double-check that the data directory exists
 		if (!is_dir($dataDir)) {
 			FileUtil::makeDir($dataDir);
 		}
-
+		
 		$output = "";
-
+		
 		// load and write out the config options
 		$config                         = array();
 		$exposedOptions                 = Config::getOption("exposedOptions");
@@ -107,7 +107,7 @@ class Builder {
 			$config[$exposedOption]     = Config::getOption($exposedOption);
 		}
 		$output     .= "var config = ".json_encode($config).";\n";
-
+		
 		// load the ish Controls
 		$ishControls     = array();
 		$controlsToHide  = array();
@@ -119,24 +119,24 @@ class Builder {
 		}
 		$ishControls["ishControlsHide"] = $controlsToHide;
 		$output      .= "var ishControls = ".json_encode($ishControls).";\n";
-
+		
 		// load and write out the items for the navigation
 		$niExporter   = new NavItemsExporter();
 		$navItems     = $niExporter->run();
 		$output      .= "var navItems = ".json_encode($navItems).";\n";
-
+		
 		// load and write out the items for the pattern paths
 		$patternPaths = array();
 		$ppdExporter  = new PatternPathDestsExporter();
 		$patternPaths = $ppdExporter->run();
 		$output      .= "var patternPaths = ".json_encode($patternPaths).";\n";
-
+		
 		// load and write out the items for the view all paths
 		$viewAllPaths = array();
 		$vapExporter  = new ViewAllPathsExporter();
 		$viewAllPaths = $vapExporter->run($navItems);
 		$output      .= "var viewAllPaths = ".json_encode($viewAllPaths).";\n";
-
+		
 		// gather plugin package information
 		$packagesInfo = array();
 		$componentDir = Config::getOption("componentDir");
@@ -167,27 +167,27 @@ class Builder {
 			}
 		}
 		$output .= "var plugins = ".json_encode($packagesInfo).";";
-
+		
 		// write out the data
 		file_put_contents($dataDir."/patternlab-data.js",$output);
-
+		
 		// note the end of the operation
 		$dispatcherInstance->dispatch("builder.generateIndexEnd");
-
+		
 	}
-
+	
 	/**
 	* Generates all of the patterns and puts them in the public directory
 	* @param   {Array}     various options that might affect the export. primarily the location.
 	*/
 	protected function generatePatterns($options = array()) {
-
+		
 		// set-up the dispatcher
 		$dispatcherInstance = Dispatcher::getInstance();
-
+		
 		// note the beginning of the operation
 		$dispatcherInstance->dispatch("builder.generatePatternsStart");
-
+		
 		// set-up common vars
 		$exportFiles      = (isset($options["exportFiles"]) && $options["exportFiles"]);
 		$exportDir        = Config::getOption("exportDir");
@@ -197,66 +197,66 @@ class Builder {
 		$suffixRendered   =	Config::getOption("outputFileSuffixes.rendered");
 		$suffixRaw        = Config::getOption("outputFileSuffixes.rawTemplate");
 		$suffixMarkupOnly = Config::getOption("outputFileSuffixes.markupOnly");
-
+		
 		// make sure the export dir exists
 		if ($exportFiles && !is_dir($exportDir)) {
 			mkdir($exportDir);
 		}
-
+		
 		// make sure patterns exists
 		if (!is_dir($patternPublicDir)) {
 			mkdir($patternPublicDir);
 		}
-
+		
 		// loop over the pattern data store to render the individual patterns
 		$store = PatternData::get();
 		foreach ($store as $patternStoreKey => $patternStoreData) {
-
+			
 			if (($patternStoreData["category"] == "pattern") && isset($patternStoreData["hidden"]) && (!$patternStoreData["hidden"])) {
-
+				
 				$path          = $patternStoreData["pathDash"];
 				$pathName      = (isset($patternStoreData["pseudo"])) ? $patternStoreData["pathOrig"] : $patternStoreData["pathName"];
-
+				
 				// modify the pattern mark-up
 				$markup        = $patternStoreData["code"];
 				$markupFull    = $patternStoreData["header"].$markup.$patternStoreData["footer"];
 				$markupEngine  = file_get_contents($patternSourceDir."/".$pathName.".".$patternExtension);
-
+				
 				// if the pattern directory doesn't exist create it
 				if (!is_dir($patternPublicDir."/".$path)) {
 					mkdir($patternPublicDir."/".$path);
 				}
-
+				
 				// write out the various pattern files
 				file_put_contents($patternPublicDir."/".$path."/".$path.$suffixRendered.".html",$markupFull);
 				if (!$exportFiles) {
 					file_put_contents($patternPublicDir."/".$path."/".$path.$suffixMarkupOnly.".html",$markup);
 					file_put_contents($patternPublicDir."/".$path."/".$path.$suffixRaw.".".$patternExtension,$markupEngine);
 				}
-
+				
 			}
-
+			
 		}
-
+		
 		// note the end of the operation
 		$dispatcherInstance->dispatch("builder.generatePatternsEnd");
-
+		
 	}
-
+	
 	/**
 	* Generates the style guide view
 	*/
 	protected function generateStyleguide() {
-
+		
 		// set-up the dispatcher
 		$dispatcherInstance = Dispatcher::getInstance();
-
+		
 		// note the beginning of the operation
 		$dispatcherInstance->dispatch("builder.generateStyleguideStart");
-
+		
 		// default var
 		$publicDir = Config::getOption("publicDir");
-
+		
 		// load the pattern loader
 		$ppdExporter             = new PatternPathSrcExporter();
 		$patternPathSrc          = $ppdExporter->run();
@@ -265,56 +265,56 @@ class Builder {
 		$patternEngineBasePath   = PatternEngine::getInstance()->getBasePath();
 		$patternLoaderClass      = $patternEngineBasePath."\Loaders\PatternLoader";
 		$patternLoader           = new $patternLoaderClass($options);
-
+		
 		// check directories i need
 		if (!is_dir($publicDir."/styleguide/")) {
 			mkdir($publicDir."/styleguide/");
 		}
-
+		
 		if (!is_dir($publicDir."/styleguide/html/")) {
 			mkdir($publicDir."/styleguide/html/");
 		}
-
+			
 		// grab the partials into a data object for the style guide
 		$ppExporter                   = new PatternPartialsExporter();
 		$partials                     = $ppExporter->run();
-
+		
 		// add the pattern data so it can be exported
 		$patternData = array();
-
+		
 		// add the pattern lab specific mark-up
 		$filesystemLoader             = Template::getFilesystemLoader();
 		$stringLoader                 = Template::getStringLoader();
-
+		
 		$globalData                   = Data::get();
 		$globalData["patternLabHead"] = $stringLoader->render(array("string" => Template::getHTMLHead(), "data" => array("cacheBuster" => $partials["cacheBuster"])));
 		$globalData["patternLabFoot"] = $stringLoader->render(array("string" => Template::getHTMLFoot(), "data" => array("cacheBuster" => $partials["cacheBuster"], "patternData" => json_encode($patternData))));
 		$globalData["viewall"]        = true;
-
+		
 		$header                       = $patternLoader->render(array("pattern" => Template::getPatternHead(), "data" => $globalData));
 		$code                         = $filesystemLoader->render(array("template" => "viewall", "data" => $partials));
 		$footer                       = $patternLoader->render(array("pattern" => Template::getPatternFoot(), "data" => $globalData));
-
+		
 		$styleGuidePage               = $header.$code.$footer;
-
+		
 		file_put_contents($publicDir."/styleguide/html/styleguide.html",$styleGuidePage);
-
+		
 		// note the end of the operation
 		$dispatcherInstance->dispatch("builder.generateStyleguideEnd");
-
+		
 	}
-
+	
 	/**
 	* Generates the view all pages
 	*/
 	protected function generateViewAllPages() {
-
+		
 		// set-up the dispatcher
 		$dispatcherInstance = Dispatcher::getInstance();
-
+		
 		// note the beginning of the operation
 		$dispatcherInstance->dispatch("builder.generateViewAllPagesStart");
-
+		
 		// default vars
 		$patternPublicDir = Config::getOption("patternPublicDir");
 		$htmlHead         = Template::getHTMLHead();
@@ -324,7 +324,7 @@ class Builder {
 		$filesystemLoader = Template::getFilesystemLoader();
 		$stringLoader     = Template::getStringLoader();
 		$globalData       = Data::get();
-
+		
 		// load the pattern loader
 		$ppdExporter             = new PatternPathSrcExporter();
 		$patternPathSrc          = $ppdExporter->run();
@@ -333,40 +333,40 @@ class Builder {
 		$patternEngineBasePath   = PatternEngine::getInstance()->getBasePath();
 		$patternLoaderClass      = $patternEngineBasePath."\Loaders\PatternLoader";
 		$patternLoader           = new $patternLoaderClass($options);
-
+		
 		// make sure view all is set
 		$globalData["viewall"] = true;
-
+		
 		// make sure the pattern dir exists
 		if (!is_dir($patternPublicDir)) {
 			mkdir($patternPublicDir);
 		}
-
+		
 		// add view all to each list
 		$store = PatternData::get();
 		foreach ($store as $patternStoreKey => $patternStoreData) {
-
+			
 			if ($patternStoreData["category"] == "patternSubtype") {
-
+				
 				// grab the partials into a data object for the style guide
 				$ppExporter  = new PatternPartialsExporter();
 				$partials    = $ppExporter->run($patternStoreData["type"],$patternStoreData["name"]);
-
+				
 				if (!empty($partials["partials"])) {
-
+					
 					// add the pattern data so it can be exported
 					$patternData = array();
 					$patternData["patternPartial"] = "viewall-".$patternStoreData["typeDash"]."-".$patternStoreData["nameDash"];
-
+					
 					$globalData["patternLabHead"] = $stringLoader->render(array("string" => Template::getHTMLHead(), "data" => array("cacheBuster" => $partials["cacheBuster"])));
 					$globalData["patternLabFoot"] = $stringLoader->render(array("string" => Template::getHTMLFoot(), "data" => array("cacheBuster" => $partials["cacheBuster"], "patternData" => json_encode($patternData))));
-
+					
 					// render the parts and join them
-					$header      = $patternLoader->render(array("pattern" => $patternHead, "data" => $partials));
+					$header      = $patternLoader->render(array("pattern" => $patternHead, "data" => $globalData));
 					$code        = $filesystemLoader->render(array("template" => "viewall", "data" => $partials));
-					$footer      = $patternLoader->render(array("pattern" => $patternFoot, "data" => $partials));
+					$footer      = $patternLoader->render(array("pattern" => $patternFoot, "data" => $globalData));
 					$viewAllPage = $header.$code.$footer;
-
+					
 					// if the pattern directory doesn't exist create it
 					$patternPath = $patternStoreData["pathDash"];
 					if (!is_dir($patternPublicDir."/".$patternPath)) {
@@ -375,31 +375,31 @@ class Builder {
 					} else {
 						file_put_contents($patternPublicDir."/".$patternPath."/index.html",$viewAllPage);
 					}
-
+					
 				}
-
+				
 			} else if (($patternStoreData["category"] == "patternType") && PatternData::hasPatternSubtype($patternStoreData["nameDash"])) {
-
+				
 				// grab the partials into a data object for the style guide
 				$ppExporter  = new PatternPartialsExporter();
 				$partials    = $ppExporter->run($patternStoreData["name"]);
-
+				
 				if (!empty($partials["partials"])) {
-
+					
 					// add the pattern data so it can be exported
 					$patternData = array();
 					$patternData["patternPartial"] = "viewall-".$patternStoreData["nameDash"]."-all";
-
+					
 					// add the pattern lab specific mark-up
 					$partials["patternLabHead"] = $stringLoader->render(array("string" => $htmlHead, "data" => array("cacheBuster" => $partials["cacheBuster"])));
 					$partials["patternLabFoot"] = $stringLoader->render(array("string" => $htmlFoot, "data" => array("cacheBuster" => $partials["cacheBuster"], "patternData" => json_encode($patternData))));
-
+					
 					// render the parts and join them
-					$header      = $patternLoader->render(array("pattern" => $patternHead, "data" => $partials));
+					$header      = $patternLoader->render(array("pattern" => $patternHead, "data" => $globalData));
 					$code        = $filesystemLoader->render(array("template" => "viewall", "data" => $partials));
-					$footer      = $patternLoader->render(array("pattern" => $patternFoot, "data" => $partials));
+					$footer      = $patternLoader->render(array("pattern" => $patternFoot, "data" => $globalData));
 					$viewAllPage = $header.$code.$footer;
-
+					
 					// if the pattern directory doesn't exist create it
 					$patternPath = $patternStoreData["pathDash"];
 					if (!is_dir($patternPublicDir."/".$patternPath)) {
@@ -408,16 +408,16 @@ class Builder {
 					} else {
 						file_put_contents($patternPublicDir."/".$patternPath."/index.html",$viewAllPage);
 					}
-
+					
 				}
-
+				
 			}
-
+			
 		}
-
+		
 		// note the end of the operation
 		$dispatcherInstance->dispatch("builder.generateViewAllPagesEnd");
-
+		
 	}
-
+	
 }

--- a/src/PatternLab/PatternData/Helpers/PatternStateHelper.php
+++ b/src/PatternLab/PatternData/Helpers/PatternStateHelper.php
@@ -47,26 +47,26 @@ class PatternStateHelper extends \PatternLab\PatternData\Helper {
 					// if this is a true pattern state, update patterns listed in reversed lineages
 					if ($patternStateDigit !== false && !empty($patternStoreData["lineagesR"])) {
 
-                        foreach ($patternStoreData["lineagesR"] as $patternCheckInfo) {
+						foreach ($patternStoreData["lineagesR"] as $patternCheckInfo) {
 
-                            $lineagePatternPartial = $patternCheckInfo["lineagePattern"];
+							$lineagePatternPartial = $patternCheckInfo["lineagePattern"];
 
-                            // if the found pattern's lineage is empty and the pattern state isn't the last (e.g. complete) add the pattern state
-                            // otherwise, if the pattern state is less than the one being checked update the pattern
-                            if ((PatternData::getPatternOption($lineagePatternPartial,"state") == "") && ($patternStateDigit != $patternStateLast)) {
+							// if the found pattern's lineage is empty and the pattern state isn't the last (e.g. complete) add the pattern state
+							// otherwise, if the pattern state is less than the one being checked update the pattern
+							if ((PatternData::getPatternOption($lineagePatternPartial,"state") == "") && ($patternStateDigit != $patternStateLast)) {
 
-                                PatternData::setPatternOption($lineagePatternPartial,"state",$patternState);
+								PatternData::setPatternOption($lineagePatternPartial,"state",$patternState);
 
-                            } else {
+							} else {
 
-                                $patternStateCheck = array_search(PatternData::getPatternOption($lineagePatternPartial,"state"), $patternStates);
-                                if ($patternStateDigit < $patternStateCheck) {
-                                    PatternData::setPatternOption($lineagePatternPartial,"state",$patternState);
-                                }
+								$patternStateCheck = array_search(PatternData::getPatternOption($lineagePatternPartial,"state"), $patternStates);
+								if ($patternStateDigit < $patternStateCheck) {
+									PatternData::setPatternOption($lineagePatternPartial,"state",$patternState);
+								}
 
-                            }
+							}
 
-                        }
+						}
 
 					}
 

--- a/src/PatternLab/PatternData/Helpers/PatternStateHelper.php
+++ b/src/PatternLab/PatternData/Helpers/PatternStateHelper.php
@@ -18,111 +18,102 @@ use \PatternLab\PatternData;
 use \PatternLab\Timer;
 
 class PatternStateHelper extends \PatternLab\PatternData\Helper {
-	
+
 	public function __construct($options = array()) {
-		
+
 		parent::__construct($options);
-		
+
 	}
-	
+
 	public function run() {
-		
+
 		// check on the states of the patterns
 		$patternStates    = Config::getOption("patternStates");
 		$patternStateLast = count($patternStates) - 1;
-		
+
 		// run through each item in the store and only look at patterns
 		$store = PatternData::get();
 		foreach ($store as $patternStoreKey => $patternStoreData) {
-			
+
 			if (($patternStoreData["category"] == "pattern") && isset($patternStoreData["state"])) {
-				
+
 				$patternState = $patternStoreData["state"];
-				
+
 				// make sure the pattern has a given state
 				if ($patternState != "") {
-					
+
 					$patternStateDigit = array_search($patternState,$patternStates);
-					
-					// if this is a true pattern state update various patterns
-					if ($patternStateDigit !== false) {
-						
-						$storeTake2 = PatternData::get();
-						foreach ($storeTake2 as $patternStoreKey2 => $patternStoreData2) {
-							
-							if (($patternStoreData2["category"] == "pattern") && isset($patternStoreData2["lineagesR"])) {
-								
-								foreach ($patternStoreData2["lineagesR"] as $patternCheckInfo) {
-									
-									$lineagePatternPartial = $patternCheckInfo["lineagePattern"];
-									
-									// if the found pattern's lineage is empty and the pattern state isn't the last (e.g. complete) add the pattern state
-									// otherwise, if the pattern state is less than the one being checked update the pattern
-									if ((PatternData::getPatternOption($lineagePatternPartial,"state") == "") && ($patternStateDigit != $patternStateLast)) {
-										
-										PatternData::setPatternOption($lineagePatternPartial,"state",$patternState);
-										
-									} else {
-										
-										$patternStateCheck = array_search(PatternData::getPatternOption($lineagePatternPartial,"state"), $patternStates);
-										if ($patternStateDigit < $patternStateCheck) {
-											PatternData::setPatternOption($lineagePatternPartial,"state",$patternState);
-										}
-										
-									}
-									
-								}
-								
-							}
-							
-						}
-						
+
+					// if this is a true pattern state, update patterns listed in reversed lineages
+					if ($patternStateDigit !== false && !empty($patternStoreData["lineagesR"])) {
+
+                        foreach ($patternStoreData["lineagesR"] as $patternCheckInfo) {
+
+                            $lineagePatternPartial = $patternCheckInfo["lineagePattern"];
+
+                            // if the found pattern's lineage is empty and the pattern state isn't the last (e.g. complete) add the pattern state
+                            // otherwise, if the pattern state is less than the one being checked update the pattern
+                            if ((PatternData::getPatternOption($lineagePatternPartial,"state") == "") && ($patternStateDigit != $patternStateLast)) {
+
+                                PatternData::setPatternOption($lineagePatternPartial,"state",$patternState);
+
+                            } else {
+
+                                $patternStateCheck = array_search(PatternData::getPatternOption($lineagePatternPartial,"state"), $patternStates);
+                                if ($patternStateDigit < $patternStateCheck) {
+                                    PatternData::setPatternOption($lineagePatternPartial,"state",$patternState);
+                                }
+
+                            }
+
+                        }
+
 					}
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 		// make sure we update the lineages with the pattern state if appropriate
 		$store = PatternData::get();
 		foreach ($store as $patternStoreKey => $patternStoreData) {
-			
+
 			if ($patternStoreData["category"] == "pattern") {
-				
+
 				if (isset($patternStoreData["lineages"]) && !empty($patternStoreData["lineages"])) {
-					
+
 					foreach ($patternStoreData["lineages"] as $patternLineageKey => $patternLineageInfo) {
-						
+
 						$lineagePattern = $patternLineageInfo["lineagePattern"];
 						$patternState   = PatternData::getPatternOption($lineagePattern,"state");
 						if (($patternState != "") && ($patternState != null)) {
 							PatternData::setPatternSubOption($patternStoreKey,"lineages",$patternLineageKey,"lineageState",$patternState);
 						}
-						
+
 					}
-					
+
 				}
-				
+
 				if (isset($patternStoreData["lineagesR"]) && !empty($patternStoreData["lineagesR"])) {
-					
+
 					foreach ($patternStoreData["lineagesR"] as $patternLineageKey => $patternLineageInfo) {
-						
+
 						$lineagePattern = $patternLineageInfo["lineagePattern"];
 						$patternState   = PatternData::getPatternOption($lineagePattern,"state");
 						if (($patternState != "") && ($patternState != null)) {
 							PatternData::setPatternSubOption($patternStoreKey,"lineagesR",$patternLineageKey,"lineageState",$patternState);
 						}
-						
+
 					}
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
+
 }


### PR DESCRIPTION
There is an issue on pattern state when the state helper evaluates partials.

Currently, setting a state on a particular pattern triggers all other patterns which contain a twig include, even if they are not related to the partial.

With this fix, only the patterns which include a particular "stated" pattern will be updated.