### PR TITLE
BUGFIX: Fix nested View All page

### DIFF
--- a/src/PatternLab/Builder.php
+++ b/src/PatternLab/Builder.php
@@ -362,9 +362,9 @@ class Builder {
 					$globalData["patternLabFoot"] = $stringLoader->render(array("string" => Template::getHTMLFoot(), "data" => array("cacheBuster" => $partials["cacheBuster"], "patternData" => json_encode($patternData))));
 					
 					// render the parts and join them
-					$header      = $patternLoader->render(array("pattern" => $patternHead, "data" => $globalData));
+					$header      = $patternLoader->render(array("pattern" => $patternHead, "data" => $partials));
 					$code        = $filesystemLoader->render(array("template" => "viewall", "data" => $partials));
-					$footer      = $patternLoader->render(array("pattern" => $patternFoot, "data" => $globalData));
+					$footer      = $patternLoader->render(array("pattern" => $patternFoot, "data" => $partials));
 					$viewAllPage = $header.$code.$footer;
 					
 					// if the pattern directory doesn't exist create it


### PR DESCRIPTION
On View All pages like for all Atoms or Molecules the general-footer is missing. The address bar, menu and pattern lab elements on the page break.
I believe this is the commit which broke things: 67c193d17442f0d4b01409c9eac8e28784ff1133
I also think this might be related to pattern-lab/patternlab-php#370 and pattern-lab/styleguidekit-assets-default#41

Sorry for the messup on the previous PR.