### PR TITLE
hack to find composer.json in a starterkit

### DIFF
--- a/src/PatternLab/Fetch.php
+++ b/src/PatternLab/Fetch.php
@@ -95,6 +95,11 @@ class Fetch {
 			Console::writeError("the starterkit needs to contain a dist/ directory before it can be installed...");
 		}
 		
+		if (!is_file($tempComposerFile)) {
+			// try without repo dir
+			$tempComposerFile  = $tempDirSK.DIRECTORY_SEPARATOR."composer.json";
+		}
+		
 		// check for composer.json. if it exists use it for determining things. otherwise just mirror dist/ to source/
 		if (file_exists($tempComposerFile)) {
 			


### PR DESCRIPTION
`Fetch` was not finding my starterkit's composer file. This mirrors the current method used to find the 'dist' directory.

