### PR TITLE
add an install script hook to composer extras

### DIFF
--- a/src/PatternLab/InstallerUtil.php
+++ b/src/PatternLab/InstallerUtil.php
@@ -289,6 +289,13 @@ class InstallerUtil {
 			
 		}
 		
+		if (isset($composerExtra["installScripts"])) {
+			foreach ($composerExtra["installScripts"] as $script) {
+				// scripts are relative to the dist directory
+				self::runInstallScript($pathDist, $script);
+			}
+		}
+		
 	}
 	
 	/**
@@ -766,6 +773,13 @@ class InstallerUtil {
 			
 		}
 		
+	}
+	
+	protected static function runInstallScript($path, $script) {
+		$script_filename = $path . DIRECTORY_SEPARATOR . $script;
+		if (file_exists($script_filename)) {
+			include($script_filename);
+		}
 	}
 	
 }


### PR DESCRIPTION
A feature request: allow misc scripts to run after starterkit installation (e.g., to move things around).

It seems a little silly to replicate composer behavior like this, but it's just a quick hack into the `composer['extras']['patternlab']` used by the starterkit fetcher.

Requires !108 to work, and you can test something like:

```
{
  "name":             "test/test-starterkit",
  "description":      "test PL starterkit.",
  "keywords":         ["twig", "pattern lab", "starterkit"],
  "type":             "patternlab-starterkit",
  "require": {
    "pattern-lab/core": "^2.0.0",
    "pattern-lab/patternengine-twig": "^2.0.0"
  },
  "extra": {
    "patternlab": {
      "dist": {
        "sourceDir": [
          { "*": "*" }
        ]
      },
      "installScripts": [
        "install/setup.php"
      ]
    }
  }
}
```