### PR TITLE
expose ishViewportRange to front-end for pattern-lab/styleguidekit-assets-default

### DIFF
--- a/src/PatternLab/Config.php
+++ b/src/PatternLab/Config.php
@@ -245,6 +245,7 @@ class Config {
 		self::setExposedOption("ishFontSize");
 		self::setExposedOption("ishMaximum");
 		self::setExposedOption("ishMinimum");
+		self::setExposedOption("ishViewportRange");
 		self::setExposedOption("outputFileSuffixes");
 		self::setExposedOption("plugins");
 		


### PR DESCRIPTION
Resolves https://github.com/pattern-lab/patternlab-php-core/issues/111