### PR TITLE
Add ability to strip pattern type category prefixes from main menu nav

### DIFF
--- a/src/PatternLab/PatternData/Exporters/NavItemsExporter.php
+++ b/src/PatternLab/PatternData/Exporters/NavItemsExporter.php
@@ -49,9 +49,19 @@ class NavItemsExporter extends \PatternLab\PatternData\Exporter {
 				
 				$bi = (count($navItems["patternTypes"]) == 0) ? 0 : $bi + 1;
 				
+				$patternTypeUC = $patternStoreData["nameClean"];
+				
+				// Strip pattern category prefixes which are optionally defined in config.yml.
+				$prefixes = Config::getOption("prefixes");
+				if (count($prefixes)) {
+					foreach ($prefixes as $prefix) {
+						$patternTypeUC = preg_replace('/^' . preg_quote($prefix, '/') . '/', '', $patternTypeUC);
+					}
+				}
+				
 				// add a new patternType to the nav
 				$navItems["patternTypes"][$bi] = array("patternTypeLC"    => strtolower($patternStoreData["nameClean"]),
-													   "patternTypeUC"    => ucwords($patternStoreData["nameClean"]),
+													   "patternTypeUC"    => ucwords($patternTypeUC),
 													   "patternType"      => $patternStoreData["name"],
 													   "patternTypeDash"  => $patternStoreData["nameDash"],
 													   "patternTypeItems" => array(),


### PR DESCRIPTION
This just cleans up the main menu navigation if you have to prefix your pattern type categories.

Pattern type category prefixes can be defined in config.yml as an array named "prefixes"
containing strings of prefixes. For example if your pattern types are called,
"theme1_atoms", "theme1_molecules", etc. you can add to your config.yml:

prefixes
  - "theme1_"

...then theme1_ will not appear in the main menu navigation of pattern lab.

Needing to prefix the top level pattern type directories is a common use case when working with multiple pattern lab instances integrated with a single Drupal 8 installation for example.