### PR TITLE
DPL: Adding Ability for Markdown Files to Specify Which Pattern It Should Be Associated With (ex. README.md)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     }
   ],
   "support": {
-    "issues":         "https://github.com/pattern-lab/patternlab-php-core/issues",
+    "issues":         "https://github.com/drupal-pattern-lab/patternlab-php-core/issues",
     "wiki":           "http://patternlab.io/docs/",
-    "source":         "https://github.com/pattern-lab/patternlab-php-core/releases"
+    "source":         "https://github.com/drupal-pattern-lab/patternlab-php-core/releases"
   },
   "autoload": {
     "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name":             "pattern-lab/core",
+  "name":             "drupal-pattern-lab/core",
   "description":      "The core functionality for Pattern Lab.",
   "keywords":         ["pattern lab", "styleguide", "style guide", "atomic", "atomic design"],
-  "homepage":         "http://patternlab.io",
+  "homepage":         "http://drupal-pattern-lab.github.io",
   "license":          "MIT",
   "authors": [
     {
@@ -18,9 +18,8 @@
     }
   ],
   "support": {
-    "issues":         "https://github.com/pattern-lab/patternlab-php-core/issues",
-    "wiki":           "http://patternlab.io/docs/",
-    "source":         "https://github.com/pattern-lab/patternlab-php-core/releases"
+    "issues":         "https://github.com/drupal-pattern-lab/patternlab-php-core/issues",
+    "source":         "https://github.com/drupal-pattern-lab/patternlab-php-core/releases"
   },
   "autoload": {
     "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name":             "drupal-pattern-lab/core",
+  "name":             "pattern-lab/core",
   "description":      "The core functionality for Pattern Lab.",
   "keywords":         ["pattern lab", "styleguide", "style guide", "atomic", "atomic design"],
-  "homepage":         "http://drupal-pattern-lab.github.io",
+  "homepage":         "http://patternlab.io",
   "license":          "MIT",
   "authors": [
     {
@@ -18,8 +18,9 @@
     }
   ],
   "support": {
-    "issues":         "https://github.com/drupal-pattern-lab/patternlab-php-core/issues",
-    "source":         "https://github.com/drupal-pattern-lab/patternlab-php-core/releases"
+    "issues":         "https://github.com/pattern-lab/patternlab-php-core/issues",
+    "wiki":           "http://patternlab.io/docs/",
+    "source":         "https://github.com/pattern-lab/patternlab-php-core/releases"
   },
   "autoload": {
     "psr-0": {

--- a/src/PatternLab/Builder.php
+++ b/src/PatternLab/Builder.php
@@ -391,8 +391,8 @@ class Builder {
 					$patternData["patternPartial"] = "viewall-".$patternStoreData["nameDash"]."-all";
 					
 					// add the pattern lab specific mark-up
-					$partials["patternLabHead"] = $stringLoader->render(array("string" => $htmlHead, "data" => array("cacheBuster" => $partials["cacheBuster"])));
-					$partials["patternLabFoot"] = $stringLoader->render(array("string" => $htmlFoot, "data" => array("cacheBuster" => $partials["cacheBuster"], "patternData" => json_encode($patternData))));
+					$globalData["patternLabHead"] = $stringLoader->render(array("string" => $htmlHead, "data" => array("cacheBuster" => $partials["cacheBuster"])));
+					$globalData["patternLabFoot"] = $stringLoader->render(array("string" => $htmlFoot, "data" => array("cacheBuster" => $partials["cacheBuster"], "patternData" => json_encode($patternData))));
 					
 					// render the parts and join them
 					$header      = $patternLoader->render(array("pattern" => $patternHead, "data" => $globalData));

--- a/src/PatternLab/Config.php
+++ b/src/PatternLab/Config.php
@@ -129,7 +129,8 @@ class Config {
 		self::$userConfigDirDash   = self::$options["baseDir"].self::$userConfigDirDash;
 		self::$userConfigDir       = (is_dir(self::$userConfigDirDash)) ? self::$userConfigDirDash : self::$userConfigDirClean;
 		self::$userConfigPath      = self::$userConfigDir.DIRECTORY_SEPARATOR.self::$userConfig;
-		self::$plConfigPath        = self::$options["baseDir"]."vendor/pattern-lab/core/".self::$plConfigPath;
+		// @todo Make folder name (i.e. `drupal-pattern-lab`) a variable
+		self::$plConfigPath        = self::$options["baseDir"]."vendor/drupal-pattern-lab/core/".self::$plConfigPath;
 		
 		// can't add __DIR__ above so adding here
 		if (!is_dir(self::$userConfigDir)) {

--- a/src/PatternLab/Config.php
+++ b/src/PatternLab/Config.php
@@ -129,8 +129,7 @@ class Config {
 		self::$userConfigDirDash   = self::$options["baseDir"].self::$userConfigDirDash;
 		self::$userConfigDir       = (is_dir(self::$userConfigDirDash)) ? self::$userConfigDirDash : self::$userConfigDirClean;
 		self::$userConfigPath      = self::$userConfigDir.DIRECTORY_SEPARATOR.self::$userConfig;
-		// @todo Make folder name (i.e. `drupal-pattern-lab`) a variable
-		self::$plConfigPath        = self::$options["baseDir"]."vendor/drupal-pattern-lab/core/".self::$plConfigPath;
+		self::$plConfigPath        = self::$options["baseDir"]."vendor/pattern-lab/core/".self::$plConfigPath;
 		
 		// can't add __DIR__ above so adding here
 		if (!is_dir(self::$userConfigDir)) {

--- a/src/PatternLab/Data.php
+++ b/src/PatternLab/Data.php
@@ -125,7 +125,7 @@ class Data {
 			$pathName      = $file->getPathname();
 			$pathNameClean = str_replace($sourceDir."/","",$pathName);
 
-			if (!$hidden && (($ext == "json") || ($ext == "yaml"))) {
+			if (!$hidden && (($ext == "json") || ($ext == "yaml") || ($ext == "yml"))) {
 
 				if ($isListItems === false) {
 
@@ -137,7 +137,7 @@ class Data {
 							JSON::lastErrorMsg($pathNameClean,$jsonErrorMessage,$data);
 						}
 
-					} else if ($ext == "yaml") {
+					} else if (($ext == "yaml") || ($ext == "yml")) {
 
 						$file = file_get_contents($pathName);
 

--- a/src/PatternLab/InstallerUtil.php
+++ b/src/PatternLab/InstallerUtil.php
@@ -349,14 +349,15 @@ class InstallerUtil {
 				// iterate over the returned objects
 				foreach ($finder as $file) {
 					
-					$ext = $file->getExtension();
+					$ext      = $file->getExtension();
+					$pathName = $file->getPathname();
 					
 					if ($ext == "css") {
-						$componentTypes["stylesheets"][] = str_replace($sourceBase.$source,$destination,$file->getPathname());
+						$componentTypes["stylesheets"][] = str_replace(DIRECTORY_SEPARATOR,"/",str_replace($sourceBase.$source,$destination,$pathName));
 					} else if ($ext == "js") {
-						$componentTypes["javascripts"][] = str_replace($sourceBase.$source,$destination,$file->getPathname());
+						$componentTypes["javascripts"][] = str_replace(DIRECTORY_SEPARATOR,"/",str_replace($sourceBase.$source,$destination,$pathName));
 					} else if ($ext == $templateExtension) {
-						$componentTypes["templates"][]   = str_replace($sourceBase.$source,$destination,$file->getPathname());
+						$componentTypes["templates"][]   = str_replace(DIRECTORY_SEPARATOR,"/",str_replace($sourceBase.$source,$destination,$pathName));
 					}
 					
 				}

--- a/src/PatternLab/PatternData.php
+++ b/src/PatternLab/PatternData.php
@@ -116,14 +116,13 @@ class PatternData {
 		if (!is_dir(Config::getOption("patternSourceDir"))) {
 			Console::writeError("having patterns is important. please make sure you've installed a starterkit and/or that ".Console::getHumanReadablePath(Config::getOption("patternSourceDir"))." exists...");
 		}
-		$patternObjects = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator(Config::getOption("patternSourceDir")), \RecursiveIteratorIterator::SELF_FIRST);
-		$patternObjects->setFlags(\FilesystemIterator::SKIP_DOTS);
+
+		$patternSourceDir = Config::getOption("patternSourceDir");
+		$patternObjects = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($patternSourceDir, \RecursiveDirectoryIterator::FOLLOW_SYMLINKS | \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::SELF_FIRST);
 
 		// sort the returned objects
 		$patternObjects = iterator_to_array($patternObjects);
 		ksort($patternObjects);
-
-		$patternSourceDir = Config::getOption("patternSourceDir");
 
 		foreach ($patternObjects as $name => $object) {
 

--- a/src/PatternLab/PatternData/Helpers/LineageHelper.php
+++ b/src/PatternLab/PatternData/Helpers/LineageHelper.php
@@ -53,6 +53,51 @@ class LineageHelper extends \PatternLab\PatternData\Helper {
 					
 					foreach ($foundLineages as $lineage) {
 						
+					/**
+						* Fix for Pattern Lab Lineages when using Twig Namespaces. 
+						* Converts the full file path to PL-friendly shorthand so 
+						* they are internally registered.
+						*
+						* 1.  Only handle instances where we aren't or can't use the 
+						*     shorthand PL path reference in templates, specifically 
+						*     in Twig / D8 when we need to use Twig namespaces in 
+						*     our template paths.
+						* 2.  Strip off the @ sign at the beginning of our $lineage string.
+						* 3.  Break apart the full lineage path based on any slashes that
+						*     may exist.
+						* 4.  Store the length of our broken up path for reference below
+						* 5.  Store the first part of the string up to the first slash "/"
+						* 6.  Now grab the last part of the pattern key, based on the length
+						*     of the path we previously exploded.
+						* 7.  Remove any "_" from pattern Name.
+						* 8.  Remove any potential prefixed numbers or number + dash 
+						*     combos on our Pattern Name.
+						* 9.  Strip off the pattern path extension (.twig, 
+						*     .mustache, etc) if it exists.
+						* 10. If the pattern name parsed had an extension, 
+						*     re-assign our Pattern Name to that.
+						* 11. Finally, re-assign $lineage to the default PL pattern key.
+						*/
+
+						if ($lineage[0] == '@') {                    /* [1] */
+							$lineage = ltrim($lineage, '@');           /* [2] */
+							$lineageParts = explode('/', $lineage);    /* [3] */
+							$length = count($lineageParts);            /* [4] */
+							$patternType = $lineageParts[0];           /* [5] */
+
+							$patternName = $lineageParts[$length - 1]; /* [6] */
+							$patternName = ltrim($patternName, '_');   /* [7] */
+							$patternName = preg_replace('/^[0-9\-]+/', '', 
+							$patternName); /* [8] */
+
+							$patternNameStripped = explode('.' . $patternExtension, $patternName); /* [9] */
+
+							if (count($patternNameStripped) > 1) { /* [10] */
+								$patternName = $patternNameStripped[0];
+							}
+							$lineage = $patternType . "-" . $patternName;	/* [11] */
+						}
+
 						if (PatternData::getOption($lineage)) {
 							
 							$patternLineages[] = array("lineagePattern" => $lineage,

--- a/src/PatternLab/PatternData/Rule.php
+++ b/src/PatternLab/PatternData/Rule.php
@@ -104,6 +104,9 @@ class Rule {
 	protected function getPatternName($pattern, $clean = true) {
 		$patternBits = explode("-",$pattern,2);
 		$patternName = (((int)$patternBits[0] != 0) || ($patternBits[0] == '00')) ? $patternBits[1] : $pattern;
+    // replace possible dots with dashes. pattern names cannot contain dots
+    // since they are used as id/class names in the styleguidekit.
+    $patternName = str_replace('.', '-', $patternName);
 		return ($clean) ? (str_replace("-"," ",$patternName)) : $patternName;
 	}
 	

--- a/src/PatternLab/PatternData/Rules/DocumentationRule.php
+++ b/src/PatternLab/PatternData/Rules/DocumentationRule.php
@@ -31,9 +31,20 @@ class DocumentationRule extends \PatternLab\PatternData\Rule {
 		$this->ignoreProp = "";
 		
 	}
-	
+
 	public function run($depth, $ext, $path, $pathName, $name) {
-		
+		// default vars
+		$patternSourceDir = Config::getOption("patternSourceDir");
+
+		// parse data
+		$text = file_get_contents($patternSourceDir.DIRECTORY_SEPARATOR.$pathName);
+		list($yaml,$markdown) = Documentation::parse($text);
+
+		if (isset($yaml["patternType"])) {
+			$name = $yaml["patternType"];
+			unset($yaml["patternType"]);
+		}
+
 		// load default vars
 		$patternType        = PatternData::getPatternType();
 		$patternTypeDash    = PatternData::getPatternTypeDash();
@@ -43,14 +54,7 @@ class DocumentationRule extends \PatternLab\PatternData\Rule {
 		$doc        = str_replace(".".$this->extProp,"",$name);              // 00-colors
 		$docDash    = $this->getPatternName(str_replace("_","",$doc),false); // colors
 		$docPartial = $patternTypeDash."-".$docDash;
-		
-		// default vars
-		$patternSourceDir = Config::getOption("patternSourceDir");
-		
-		// parse data
-		$text = file_get_contents($patternSourceDir.DIRECTORY_SEPARATOR.$pathName);
-		list($yaml,$markdown) = Documentation::parse($text);
-		
+
 		// grab the title and unset it from the yaml so it doesn't get duped in the meta
 		if (isset($yaml["title"])) {
 			$title = $yaml["title"];
@@ -68,9 +72,8 @@ class DocumentationRule extends \PatternLab\PatternData\Rule {
 					break;
 				}
 			}
-			
 		}
-		
+
 		$category         = ($patternSubtypeDoc) ? "patternSubtype" : "pattern";
 		$patternStoreKey  = ($patternSubtypeDoc) ? $docPartial."-plsubtype" : $docPartial;
 		

--- a/src/PatternLab/PatternData/Rules/PseudoPatternRule.php
+++ b/src/PatternLab/PatternData/Rules/PseudoPatternRule.php
@@ -171,7 +171,14 @@ class PseudoPatternRule extends \PatternLab\PatternData\Rule {
 		$patternStoreData["data"] = is_array($patternData) ? array_replace_recursive($patternDataBase, $patternData) : $patternDataBase;
 
 		// if the pattern data store already exists make sure it is merged and overwrites this data
-		$patternStoreData = (PatternData::checkOption($patternStoreKey)) ? array_replace_recursive(PatternData::getOption($patternStoreKey),$patternStoreData) : $patternStoreData;
+    if (PatternData::checkOption($patternStoreKey)) {
+      $existingData = PatternData::getOption($patternStoreKey);
+      if (array_key_exists('nameClean', $existingData)) {
+        // don't overwrite nameClean
+        unset($patternStoreData['nameClean']);
+      }
+      $patternStoreData = array_replace_recursive($existingData, $patternStoreData);
+    }
 		PatternData::setOption($patternStoreKey, $patternStoreData);
 
 	}


### PR DESCRIPTION
[Original pull request](https://github.com/drupal-pattern-lab/patternlab-php-core/pull/18) from the Drupal Pattern Lab Fork  which already merged in [these 9 ](https://github.com/drupal-pattern-lab/patternlab-php-core/pulls?q=is%3Apr+is%3Aclosed) previous PRs.

For example, if I had a colors.twig file in my code with a README.md file living right next to it (living in a colors folder), currently this file is completely ignored by Pattern Lab.

This update adds the ability to specify a `patternType` option in the markdown file's front matter to tell Pattern Lab which pattern it should be associated with (or more specifically, which patternType it should be associated with).

```
---
title: Color Palette
patternType: colors
---

Our primary palette consists of our primary brand color...
```

Besides offering more flexible in how files are named, this also helps make Pattern Lab much friendlier to monorepo projects where each pattern might be individually versioned, documented, and published to NPM and/or Github where README.md filenames provide a better user experience if browsing a pattern's source files.

CC @aleksip @EvanLovely @evanmwillhite 