### PR TITLE
DPL: Reference The Correct Template In Psuedo Patterns If JSON File and Template Live in Different Folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![license](https://img.shields.io/github/license/pattern-lab/patternlab-php-core.svg)
-[![Packagist](https://img.shields.io/packagist/v/pattern-lab/core.svg)](https://packagist.org/packages/pattern-lab/core) [![Gitter](https://img.shields.io/gitter/room/pattern-lab/php.svg)](https://gitter.im/pattern-lab/php)
+[![Gitter](https://img.shields.io/gitter/room/pattern-lab/php.svg)](https://gitter.im/pattern-lab/php)
 
 # Pattern Lab Core
 

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     }
   ],
   "support": {
-    "issues":         "https://github.com/pattern-lab/patternlab-php-core/issues",
+    "issues":         "https://github.com/drupal-pattern-lab/patternlab-php-core/issues",
     "wiki":           "http://patternlab.io/docs/",
-    "source":         "https://github.com/pattern-lab/patternlab-php-core/releases"
+    "source":         "https://github.com/drupal-pattern-lab/patternlab-php-core/releases"
   },
   "autoload": {
     "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name":             "pattern-lab/core",
+  "name":             "drupal-pattern-lab/core",
   "description":      "The core functionality for Pattern Lab.",
   "keywords":         ["pattern lab", "styleguide", "style guide", "atomic", "atomic design"],
-  "homepage":         "http://patternlab.io",
+  "homepage":         "http://drupal-pattern-lab.github.io",
   "license":          "MIT",
   "authors": [
     {
@@ -18,9 +18,8 @@
     }
   ],
   "support": {
-    "issues":         "https://github.com/pattern-lab/patternlab-php-core/issues",
-    "wiki":           "http://patternlab.io/docs/",
-    "source":         "https://github.com/pattern-lab/patternlab-php-core/releases"
+    "issues":         "https://github.com/drupal-pattern-lab/patternlab-php-core/issues",
+    "source":         "https://github.com/drupal-pattern-lab/patternlab-php-core/releases"
   },
   "autoload": {
     "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name":             "drupal-pattern-lab/core",
+  "name":             "pattern-lab/core",
   "description":      "The core functionality for Pattern Lab.",
   "keywords":         ["pattern lab", "styleguide", "style guide", "atomic", "atomic design"],
-  "homepage":         "http://drupal-pattern-lab.github.io",
+  "homepage":         "http://patternlab.io",
   "license":          "MIT",
   "authors": [
     {
@@ -18,8 +18,9 @@
     }
   ],
   "support": {
-    "issues":         "https://github.com/drupal-pattern-lab/patternlab-php-core/issues",
-    "source":         "https://github.com/drupal-pattern-lab/patternlab-php-core/releases"
+    "issues":         "https://github.com/pattern-lab/patternlab-php-core/issues",
+    "wiki":           "http://patternlab.io/docs/",
+    "source":         "https://github.com/pattern-lab/patternlab-php-core/releases"
   },
   "autoload": {
     "psr-0": {

--- a/src/PatternLab/Builder.php
+++ b/src/PatternLab/Builder.php
@@ -391,8 +391,8 @@ class Builder {
 					$patternData["patternPartial"] = "viewall-".$patternStoreData["nameDash"]."-all";
 					
 					// add the pattern lab specific mark-up
-					$partials["patternLabHead"] = $stringLoader->render(array("string" => $htmlHead, "data" => array("cacheBuster" => $partials["cacheBuster"])));
-					$partials["patternLabFoot"] = $stringLoader->render(array("string" => $htmlFoot, "data" => array("cacheBuster" => $partials["cacheBuster"], "patternData" => json_encode($patternData))));
+					$globalData["patternLabHead"] = $stringLoader->render(array("string" => $htmlHead, "data" => array("cacheBuster" => $partials["cacheBuster"])));
+					$globalData["patternLabFoot"] = $stringLoader->render(array("string" => $htmlFoot, "data" => array("cacheBuster" => $partials["cacheBuster"], "patternData" => json_encode($patternData))));
 					
 					// render the parts and join them
 					$header      = $patternLoader->render(array("pattern" => $patternHead, "data" => $globalData));

--- a/src/PatternLab/Builder.php
+++ b/src/PatternLab/Builder.php
@@ -261,6 +261,20 @@ class Builder {
 				// modify the pattern mark-up
 				$markup        = $patternStoreData["code"];
 				$markupFull    = $patternStoreData["header"].$markup.$patternStoreData["footer"];
+
+
+				/** If the base template for a JSON / Yaml file (or psuedo pattern variation) lives in a different folder, 
+					* use the `original` pattern's template instead. 
+					* Fixes https://github.com/drupal-pattern-lab/patternlab-php-core/issues/22
+					*/
+				if (!file_exists($patternSourceDir."/".$pathName.".".$patternExtension)){
+					$originalPatternPathName = PatternData::getOption($patternStoreData["original"])["pathName"];
+					if (file_exists($patternSourceDir."/".$originalPatternPathName.".".$patternExtension)){
+						$pathName = $originalPatternPathName;
+					}
+				}
+
+
 				$markupEngine  = file_get_contents($patternSourceDir."/".$pathName.".".$patternExtension);
 
 				// if the pattern directory doesn't exist create it

--- a/src/PatternLab/Builder.php
+++ b/src/PatternLab/Builder.php
@@ -29,77 +29,118 @@ use \PatternLab\Timer;
 use \Symfony\Component\Finder\Finder;
 
 class Builder {
-	
+
 	/**
 	* When initializing the Builder class make sure the template helper is set-up
 	*/
 	public function __construct() {
-		
+
 		// set-up the pattern engine
 		PatternEngine::init();
-		
+
 		// set-up the various attributes for rendering templates
 		Template::init();
-		
+
 	}
-	
+
 	/**
 	* Generates the annotations js file
 	*/
 	protected function generateAnnotations() {
-		
+
 		// set-up the dispatcher
 		$dispatcherInstance = Dispatcher::getInstance();
-		
+
 		// note the start of the operation
 		$dispatcherInstance->dispatch("builder.generateAnnotationsStart");
-		
+
 		// default var
 		$publicDir = Config::getOption("publicDir");
-		
+
 		// encode the content so it can be written out
 		$json      = json_encode(Annotations::get());
-		
+
 		// make sure annotations/ exists
 		if (!is_dir($publicDir."/annotations")) {
 			mkdir($publicDir."/annotations");
 		}
-		
+
 		// write out the new annotations.js file
 		file_put_contents($publicDir."/annotations/annotations.js","var comments = ".$json.";");
-		
+
 		// note the end of the operation
 		$dispatcherInstance->dispatch("builder.generateAnnotationsEnd");
-		
+
 	}
-	
+
 	/**
 	* Generates the data that powers the index page
 	*/
 	protected function generateIndex() {
-		
-		// bomb if missing index.html
+
+		/**
+			*  Handle missing index.html. Solves https://github.com/drupal-pattern-lab/patternlab-php-core/issues/14
+			*  Could also be used to re-add missing styleguidekit assets with a few edits?
+			*
+			*  1. @TODO: Figure out a better way to future-proof path resolution for styleguidekit `dist` folder
+			*  2. Recusirively copy files from styleguidekit to publicDir via https://stackoverflow.com/a/7775949
+			*  3. Make sure we only try to create new directories if they don't already exist
+			*  4. Only copy files if they are missing (vs changed, etc)
+			*/
 		if (!file_exists(Config::getOption("publicDir")."/index.html")) {
 			$index = Console::getHumanReadablePath(Config::getOption("publicDir")).DIRECTORY_SEPARATOR."index.html";
-			Console::writeError("<path>".$index."</path> is missing. grab a copy from your StyleguideKit...");
+			Console::writeWarning($index . " is missing. No biggie. Grabbing a fresh copy from your StyleguideKit...");
+
+			$baseDir = Config::getOption("baseDir") . '/vendor';
+			$finder = new Finder();
+
+			// Locate the current theme's styleguidekit assets via the patternlab-styleguidekit `type` in composer.json
+			$finder->files()->name("composer.json")->in($baseDir)->contains('patternlab-styleguidekit')->sortByName();
+
+			foreach ($finder as $file) {
+				$src = dirname($file->getRealPath()) . DIRECTORY_SEPARATOR . 'dist'; /* [1] */
+				$dest= Config::getOption("publicDir");
+
+				if (is_dir($src)){
+
+					if(!is_dir($dest)) {
+						mkdir($dest, 0755);
+	        }
+
+	        foreach ( /* [2] */
+						$iterator = new \RecursiveIteratorIterator(
+							new \RecursiveDirectoryIterator($src, \RecursiveDirectoryIterator::SKIP_DOTS), \RecursiveIteratorIterator::SELF_FIRST) as $item
+					) {
+						if ($item->isDir()) {
+							if(!is_dir($dest . DIRECTORY_SEPARATOR . $iterator->getSubPathName())) { /* [3] */
+								mkdir($dest . DIRECTORY_SEPARATOR . $iterator->getSubPathName());
+							}
+						} else {
+							if(!file_exists($dest . DIRECTORY_SEPARATOR . $iterator->getSubPathName())) { /* [4] */
+								copy($item, $dest . DIRECTORY_SEPARATOR . $iterator->getSubPathName());
+							}
+						}
+					}
+				}
+			}
 		}
-		
+
 		// set-up the dispatcher
 		$dispatcherInstance = Dispatcher::getInstance();
-		
+
 		// note the start of the operation
 		$dispatcherInstance->dispatch("builder.generateIndexStart");
-		
+
 		// default var
 		$dataDir = Config::getOption("publicDir")."/styleguide/data";
-		
+
 		// double-check that the data directory exists
 		if (!is_dir($dataDir)) {
 			FileUtil::makeDir($dataDir);
 		}
-		
+
 		$output = "";
-		
+
 		// load and write out the config options
 		$config                         = array();
 		$exposedOptions                 = Config::getOption("exposedOptions");
@@ -107,7 +148,7 @@ class Builder {
 			$config[$exposedOption]     = Config::getOption($exposedOption);
 		}
 		$output     .= "var config = ".json_encode($config).";\n";
-		
+
 		// load the ish Controls
 		$ishControls     = array();
 		$controlsToHide  = array();
@@ -119,24 +160,24 @@ class Builder {
 		}
 		$ishControls["ishControlsHide"] = $controlsToHide;
 		$output      .= "var ishControls = ".json_encode($ishControls).";\n";
-		
+
 		// load and write out the items for the navigation
 		$niExporter   = new NavItemsExporter();
 		$navItems     = $niExporter->run();
 		$output      .= "var navItems = ".json_encode($navItems).";\n";
-		
+
 		// load and write out the items for the pattern paths
 		$patternPaths = array();
 		$ppdExporter  = new PatternPathDestsExporter();
 		$patternPaths = $ppdExporter->run();
 		$output      .= "var patternPaths = ".json_encode($patternPaths).";\n";
-		
+
 		// load and write out the items for the view all paths
 		$viewAllPaths = array();
 		$vapExporter  = new ViewAllPathsExporter();
 		$viewAllPaths = $vapExporter->run($navItems);
 		$output      .= "var viewAllPaths = ".json_encode($viewAllPaths).";\n";
-		
+
 		// gather plugin package information
 		$packagesInfo = array();
 		$componentDir = Config::getOption("componentDir");
@@ -167,27 +208,27 @@ class Builder {
 			}
 		}
 		$output .= "var plugins = ".json_encode($packagesInfo).";";
-		
+
 		// write out the data
 		file_put_contents($dataDir."/patternlab-data.js",$output);
-		
+
 		// note the end of the operation
 		$dispatcherInstance->dispatch("builder.generateIndexEnd");
-		
+
 	}
-	
+
 	/**
 	* Generates all of the patterns and puts them in the public directory
 	* @param   {Array}     various options that might affect the export. primarily the location.
 	*/
 	protected function generatePatterns($options = array()) {
-		
+
 		// set-up the dispatcher
 		$dispatcherInstance = Dispatcher::getInstance();
-		
+
 		// note the beginning of the operation
 		$dispatcherInstance->dispatch("builder.generatePatternsStart");
-		
+
 		// set-up common vars
 		$exportFiles      = (isset($options["exportFiles"]) && $options["exportFiles"]);
 		$exportDir        = Config::getOption("exportDir");
@@ -197,66 +238,66 @@ class Builder {
 		$suffixRendered   =	Config::getOption("outputFileSuffixes.rendered");
 		$suffixRaw        = Config::getOption("outputFileSuffixes.rawTemplate");
 		$suffixMarkupOnly = Config::getOption("outputFileSuffixes.markupOnly");
-		
+
 		// make sure the export dir exists
 		if ($exportFiles && !is_dir($exportDir)) {
 			mkdir($exportDir);
 		}
-		
+
 		// make sure patterns exists
 		if (!is_dir($patternPublicDir)) {
 			mkdir($patternPublicDir);
 		}
-		
+
 		// loop over the pattern data store to render the individual patterns
 		$store = PatternData::get();
 		foreach ($store as $patternStoreKey => $patternStoreData) {
-			
+
 			if (($patternStoreData["category"] == "pattern") && isset($patternStoreData["hidden"]) && (!$patternStoreData["hidden"])) {
-				
+
 				$path          = $patternStoreData["pathDash"];
 				$pathName      = (isset($patternStoreData["pseudo"])) ? $patternStoreData["pathOrig"] : $patternStoreData["pathName"];
-				
+
 				// modify the pattern mark-up
 				$markup        = $patternStoreData["code"];
 				$markupFull    = $patternStoreData["header"].$markup.$patternStoreData["footer"];
 				$markupEngine  = file_get_contents($patternSourceDir."/".$pathName.".".$patternExtension);
-				
+
 				// if the pattern directory doesn't exist create it
 				if (!is_dir($patternPublicDir."/".$path)) {
 					mkdir($patternPublicDir."/".$path);
 				}
-				
+
 				// write out the various pattern files
 				file_put_contents($patternPublicDir."/".$path."/".$path.$suffixRendered.".html",$markupFull);
 				if (!$exportFiles) {
 					file_put_contents($patternPublicDir."/".$path."/".$path.$suffixMarkupOnly.".html",$markup);
 					file_put_contents($patternPublicDir."/".$path."/".$path.$suffixRaw.".".$patternExtension,$markupEngine);
 				}
-				
+
 			}
-			
+
 		}
-		
+
 		// note the end of the operation
 		$dispatcherInstance->dispatch("builder.generatePatternsEnd");
-		
+
 	}
-	
+
 	/**
 	* Generates the style guide view
 	*/
 	protected function generateStyleguide() {
-		
+
 		// set-up the dispatcher
 		$dispatcherInstance = Dispatcher::getInstance();
-		
+
 		// note the beginning of the operation
 		$dispatcherInstance->dispatch("builder.generateStyleguideStart");
-		
+
 		// default var
 		$publicDir = Config::getOption("publicDir");
-		
+
 		// load the pattern loader
 		$ppdExporter             = new PatternPathSrcExporter();
 		$patternPathSrc          = $ppdExporter->run();
@@ -265,56 +306,56 @@ class Builder {
 		$patternEngineBasePath   = PatternEngine::getInstance()->getBasePath();
 		$patternLoaderClass      = $patternEngineBasePath."\Loaders\PatternLoader";
 		$patternLoader           = new $patternLoaderClass($options);
-		
+
 		// check directories i need
 		if (!is_dir($publicDir."/styleguide/")) {
 			mkdir($publicDir."/styleguide/");
 		}
-		
+
 		if (!is_dir($publicDir."/styleguide/html/")) {
 			mkdir($publicDir."/styleguide/html/");
 		}
-			
+
 		// grab the partials into a data object for the style guide
 		$ppExporter                   = new PatternPartialsExporter();
 		$partials                     = $ppExporter->run();
-		
+
 		// add the pattern data so it can be exported
 		$patternData = array();
-		
+
 		// add the pattern lab specific mark-up
 		$filesystemLoader             = Template::getFilesystemLoader();
 		$stringLoader                 = Template::getStringLoader();
-		
+
 		$globalData                   = Data::get();
 		$globalData["patternLabHead"] = $stringLoader->render(array("string" => Template::getHTMLHead(), "data" => array("cacheBuster" => $partials["cacheBuster"])));
 		$globalData["patternLabFoot"] = $stringLoader->render(array("string" => Template::getHTMLFoot(), "data" => array("cacheBuster" => $partials["cacheBuster"], "patternData" => json_encode($patternData))));
 		$globalData["viewall"]        = true;
-		
+
 		$header                       = $patternLoader->render(array("pattern" => Template::getPatternHead(), "data" => $globalData));
 		$code                         = $filesystemLoader->render(array("template" => "viewall", "data" => $partials));
 		$footer                       = $patternLoader->render(array("pattern" => Template::getPatternFoot(), "data" => $globalData));
-		
+
 		$styleGuidePage               = $header.$code.$footer;
-		
+
 		file_put_contents($publicDir."/styleguide/html/styleguide.html",$styleGuidePage);
-		
+
 		// note the end of the operation
 		$dispatcherInstance->dispatch("builder.generateStyleguideEnd");
-		
+
 	}
-	
+
 	/**
 	* Generates the view all pages
 	*/
 	protected function generateViewAllPages() {
-		
+
 		// set-up the dispatcher
 		$dispatcherInstance = Dispatcher::getInstance();
-		
+
 		// note the beginning of the operation
 		$dispatcherInstance->dispatch("builder.generateViewAllPagesStart");
-		
+
 		// default vars
 		$patternPublicDir = Config::getOption("patternPublicDir");
 		$htmlHead         = Template::getHTMLHead();
@@ -324,7 +365,7 @@ class Builder {
 		$filesystemLoader = Template::getFilesystemLoader();
 		$stringLoader     = Template::getStringLoader();
 		$globalData       = Data::get();
-		
+
 		// load the pattern loader
 		$ppdExporter             = new PatternPathSrcExporter();
 		$patternPathSrc          = $ppdExporter->run();
@@ -333,40 +374,40 @@ class Builder {
 		$patternEngineBasePath   = PatternEngine::getInstance()->getBasePath();
 		$patternLoaderClass      = $patternEngineBasePath."\Loaders\PatternLoader";
 		$patternLoader           = new $patternLoaderClass($options);
-		
+
 		// make sure view all is set
 		$globalData["viewall"] = true;
-		
+
 		// make sure the pattern dir exists
 		if (!is_dir($patternPublicDir)) {
 			mkdir($patternPublicDir);
 		}
-		
+
 		// add view all to each list
 		$store = PatternData::get();
 		foreach ($store as $patternStoreKey => $patternStoreData) {
-			
+
 			if ($patternStoreData["category"] == "patternSubtype") {
-				
+
 				// grab the partials into a data object for the style guide
 				$ppExporter  = new PatternPartialsExporter();
 				$partials    = $ppExporter->run($patternStoreData["type"],$patternStoreData["name"]);
-				
+
 				if (!empty($partials["partials"])) {
-					
+
 					// add the pattern data so it can be exported
 					$patternData = array();
 					$patternData["patternPartial"] = "viewall-".$patternStoreData["typeDash"]."-".$patternStoreData["nameDash"];
-					
+
 					$globalData["patternLabHead"] = $stringLoader->render(array("string" => Template::getHTMLHead(), "data" => array("cacheBuster" => $partials["cacheBuster"])));
 					$globalData["patternLabFoot"] = $stringLoader->render(array("string" => Template::getHTMLFoot(), "data" => array("cacheBuster" => $partials["cacheBuster"], "patternData" => json_encode($patternData))));
-					
+
 					// render the parts and join them
 					$header      = $patternLoader->render(array("pattern" => $patternHead, "data" => $globalData));
 					$code        = $filesystemLoader->render(array("template" => "viewall", "data" => $partials));
 					$footer      = $patternLoader->render(array("pattern" => $patternFoot, "data" => $globalData));
 					$viewAllPage = $header.$code.$footer;
-					
+
 					// if the pattern directory doesn't exist create it
 					$patternPath = $patternStoreData["pathDash"];
 					if (!is_dir($patternPublicDir."/".$patternPath)) {
@@ -375,31 +416,31 @@ class Builder {
 					} else {
 						file_put_contents($patternPublicDir."/".$patternPath."/index.html",$viewAllPage);
 					}
-					
+
 				}
-				
+
 			} else if (($patternStoreData["category"] == "patternType") && PatternData::hasPatternSubtype($patternStoreData["nameDash"])) {
-				
+
 				// grab the partials into a data object for the style guide
 				$ppExporter  = new PatternPartialsExporter();
 				$partials    = $ppExporter->run($patternStoreData["name"]);
-				
+
 				if (!empty($partials["partials"])) {
-					
+
 					// add the pattern data so it can be exported
 					$patternData = array();
 					$patternData["patternPartial"] = "viewall-".$patternStoreData["nameDash"]."-all";
-					
+
 					// add the pattern lab specific mark-up
 					$globalData["patternLabHead"] = $stringLoader->render(array("string" => $htmlHead, "data" => array("cacheBuster" => $partials["cacheBuster"])));
 					$globalData["patternLabFoot"] = $stringLoader->render(array("string" => $htmlFoot, "data" => array("cacheBuster" => $partials["cacheBuster"], "patternData" => json_encode($patternData))));
-					
+
 					// render the parts and join them
 					$header      = $patternLoader->render(array("pattern" => $patternHead, "data" => $globalData));
 					$code        = $filesystemLoader->render(array("template" => "viewall", "data" => $partials));
 					$footer      = $patternLoader->render(array("pattern" => $patternFoot, "data" => $globalData));
 					$viewAllPage = $header.$code.$footer;
-					
+
 					// if the pattern directory doesn't exist create it
 					$patternPath = $patternStoreData["pathDash"];
 					if (!is_dir($patternPublicDir."/".$patternPath)) {
@@ -408,16 +449,16 @@ class Builder {
 					} else {
 						file_put_contents($patternPublicDir."/".$patternPath."/index.html",$viewAllPage);
 					}
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 		// note the end of the operation
 		$dispatcherInstance->dispatch("builder.generateViewAllPagesEnd");
-		
+
 	}
-	
+
 }

--- a/src/PatternLab/Config.php
+++ b/src/PatternLab/Config.php
@@ -129,7 +129,8 @@ class Config {
 		self::$userConfigDirDash   = self::$options["baseDir"].self::$userConfigDirDash;
 		self::$userConfigDir       = (is_dir(self::$userConfigDirDash)) ? self::$userConfigDirDash : self::$userConfigDirClean;
 		self::$userConfigPath      = self::$userConfigDir.DIRECTORY_SEPARATOR.self::$userConfig;
-		self::$plConfigPath        = self::$options["baseDir"]."vendor/pattern-lab/core/".self::$plConfigPath;
+		// @todo Make folder name (i.e. `drupal-pattern-lab`) a variable
+		self::$plConfigPath        = self::$options["baseDir"]."vendor/drupal-pattern-lab/core/".self::$plConfigPath;
 		
 		// can't add __DIR__ above so adding here
 		if (!is_dir(self::$userConfigDir)) {

--- a/src/PatternLab/Config.php
+++ b/src/PatternLab/Config.php
@@ -129,8 +129,7 @@ class Config {
 		self::$userConfigDirDash   = self::$options["baseDir"].self::$userConfigDirDash;
 		self::$userConfigDir       = (is_dir(self::$userConfigDirDash)) ? self::$userConfigDirDash : self::$userConfigDirClean;
 		self::$userConfigPath      = self::$userConfigDir.DIRECTORY_SEPARATOR.self::$userConfig;
-		// @todo Make folder name (i.e. `drupal-pattern-lab`) a variable
-		self::$plConfigPath        = self::$options["baseDir"]."vendor/drupal-pattern-lab/core/".self::$plConfigPath;
+		self::$plConfigPath        = self::$options["baseDir"]."vendor/pattern-lab/core/".self::$plConfigPath;
 		
 		// can't add __DIR__ above so adding here
 		if (!is_dir(self::$userConfigDir)) {

--- a/src/PatternLab/Data.php
+++ b/src/PatternLab/Data.php
@@ -125,7 +125,7 @@ class Data {
 			$pathName      = $file->getPathname();
 			$pathNameClean = str_replace($sourceDir."/","",$pathName);
 
-			if (!$hidden && (($ext == "json") || ($ext == "yaml"))) {
+			if (!$hidden && (($ext == "json") || ($ext == "yaml") || ($ext == "yml"))) {
 
 				if ($isListItems === false) {
 
@@ -137,7 +137,7 @@ class Data {
 							JSON::lastErrorMsg($pathNameClean,$jsonErrorMessage,$data);
 						}
 
-					} else if ($ext == "yaml") {
+					} else if (($ext == "yaml") || ($ext == "yml")) {
 
 						$file = file_get_contents($pathName);
 

--- a/src/PatternLab/InstallerUtil.php
+++ b/src/PatternLab/InstallerUtil.php
@@ -349,14 +349,15 @@ class InstallerUtil {
 				// iterate over the returned objects
 				foreach ($finder as $file) {
 					
-					$ext = $file->getExtension();
+					$ext      = $file->getExtension();
+					$pathName = $file->getPathname();
 					
 					if ($ext == "css") {
-						$componentTypes["stylesheets"][] = str_replace($sourceBase.$source,$destination,$file->getPathname());
+						$componentTypes["stylesheets"][] = str_replace(DIRECTORY_SEPARATOR,"/",str_replace($sourceBase.$source,$destination,$pathName));
 					} else if ($ext == "js") {
-						$componentTypes["javascripts"][] = str_replace($sourceBase.$source,$destination,$file->getPathname());
+						$componentTypes["javascripts"][] = str_replace(DIRECTORY_SEPARATOR,"/",str_replace($sourceBase.$source,$destination,$pathName));
 					} else if ($ext == $templateExtension) {
-						$componentTypes["templates"][]   = str_replace($sourceBase.$source,$destination,$file->getPathname());
+						$componentTypes["templates"][]   = str_replace(DIRECTORY_SEPARATOR,"/",str_replace($sourceBase.$source,$destination,$pathName));
 					}
 					
 				}

--- a/src/PatternLab/PatternData.php
+++ b/src/PatternLab/PatternData.php
@@ -116,14 +116,13 @@ class PatternData {
 		if (!is_dir(Config::getOption("patternSourceDir"))) {
 			Console::writeError("having patterns is important. please make sure you've installed a starterkit and/or that ".Console::getHumanReadablePath(Config::getOption("patternSourceDir"))." exists...");
 		}
-		$patternObjects = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator(Config::getOption("patternSourceDir")), \RecursiveIteratorIterator::SELF_FIRST);
-		$patternObjects->setFlags(\FilesystemIterator::SKIP_DOTS);
+
+		$patternSourceDir = Config::getOption("patternSourceDir");
+		$patternObjects = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($patternSourceDir, \RecursiveDirectoryIterator::FOLLOW_SYMLINKS | \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::SELF_FIRST);
 
 		// sort the returned objects
 		$patternObjects = iterator_to_array($patternObjects);
 		ksort($patternObjects);
-
-		$patternSourceDir = Config::getOption("patternSourceDir");
 
 		foreach ($patternObjects as $name => $object) {
 

--- a/src/PatternLab/PatternData/Helpers/LineageHelper.php
+++ b/src/PatternLab/PatternData/Helpers/LineageHelper.php
@@ -53,6 +53,51 @@ class LineageHelper extends \PatternLab\PatternData\Helper {
 					
 					foreach ($foundLineages as $lineage) {
 						
+					/**
+						* Fix for Pattern Lab Lineages when using Twig Namespaces. 
+						* Converts the full file path to PL-friendly shorthand so 
+						* they are internally registered.
+						*
+						* 1.  Only handle instances where we aren't or can't use the 
+						*     shorthand PL path reference in templates, specifically 
+						*     in Twig / D8 when we need to use Twig namespaces in 
+						*     our template paths.
+						* 2.  Strip off the @ sign at the beginning of our $lineage string.
+						* 3.  Break apart the full lineage path based on any slashes that
+						*     may exist.
+						* 4.  Store the length of our broken up path for reference below
+						* 5.  Store the first part of the string up to the first slash "/"
+						* 6.  Now grab the last part of the pattern key, based on the length
+						*     of the path we previously exploded.
+						* 7.  Remove any "_" from pattern Name.
+						* 8.  Remove any potential prefixed numbers or number + dash 
+						*     combos on our Pattern Name.
+						* 9.  Strip off the pattern path extension (.twig, 
+						*     .mustache, etc) if it exists.
+						* 10. If the pattern name parsed had an extension, 
+						*     re-assign our Pattern Name to that.
+						* 11. Finally, re-assign $lineage to the default PL pattern key.
+						*/
+
+						if ($lineage[0] == '@') {                    /* [1] */
+							$lineage = ltrim($lineage, '@');           /* [2] */
+							$lineageParts = explode('/', $lineage);    /* [3] */
+							$length = count($lineageParts);            /* [4] */
+							$patternType = $lineageParts[0];           /* [5] */
+
+							$patternName = $lineageParts[$length - 1]; /* [6] */
+							$patternName = ltrim($patternName, '_');   /* [7] */
+							$patternName = preg_replace('/^[0-9\-]+/', '', 
+							$patternName); /* [8] */
+
+							$patternNameStripped = explode('.' . $patternExtension, $patternName); /* [9] */
+
+							if (count($patternNameStripped) > 1) { /* [10] */
+								$patternName = $patternNameStripped[0];
+							}
+							$lineage = $patternType . "-" . $patternName;	/* [11] */
+						}
+
 						if (PatternData::getOption($lineage)) {
 							
 							$patternLineages[] = array("lineagePattern" => $lineage,

--- a/src/PatternLab/PatternData/Rule.php
+++ b/src/PatternLab/PatternData/Rule.php
@@ -104,6 +104,9 @@ class Rule {
 	protected function getPatternName($pattern, $clean = true) {
 		$patternBits = explode("-",$pattern,2);
 		$patternName = (((int)$patternBits[0] != 0) || ($patternBits[0] == '00')) ? $patternBits[1] : $pattern;
+    // replace possible dots with dashes. pattern names cannot contain dots
+    // since they are used as id/class names in the styleguidekit.
+    $patternName = str_replace('.', '-', $patternName);
 		return ($clean) ? (str_replace("-"," ",$patternName)) : $patternName;
 	}
 	

--- a/src/PatternLab/PatternData/Rules/PseudoPatternRule.php
+++ b/src/PatternLab/PatternData/Rules/PseudoPatternRule.php
@@ -171,7 +171,14 @@ class PseudoPatternRule extends \PatternLab\PatternData\Rule {
 		$patternStoreData["data"] = is_array($patternData) ? array_replace_recursive($patternDataBase, $patternData) : $patternDataBase;
 
 		// if the pattern data store already exists make sure it is merged and overwrites this data
-		$patternStoreData = (PatternData::checkOption($patternStoreKey)) ? array_replace_recursive(PatternData::getOption($patternStoreKey),$patternStoreData) : $patternStoreData;
+    if (PatternData::checkOption($patternStoreKey)) {
+      $existingData = PatternData::getOption($patternStoreKey);
+      if (array_key_exists('nameClean', $existingData)) {
+        // don't overwrite nameClean
+        unset($patternStoreData['nameClean']);
+      }
+      $patternStoreData = array_replace_recursive($existingData, $patternStoreData);
+    }
 		PatternData::setOption($patternStoreKey, $patternStoreData);
 
 	}


### PR DESCRIPTION
[Original pull request](https://github.com/drupal-pattern-lab/patternlab-php-core/pull/23) from the Drupal Pattern Lab Fork  which already merged in [these 9 ](https://github.com/drupal-pattern-lab/patternlab-php-core/pulls?q=is%3Apr+is%3Aclosed) previous PRs.

Fixes this long existing (and rather annoying) issue with psuedo patterns throwing errors left and right if the template a psueo-pattern is based on ends up living in a separate folder.

Addresses https://github.com/drupal-pattern-lab/patternlab-php-core/issues/22

<img width="289" alt="builder_php_ _bolt" src="https://user-images.githubusercontent.com/1617209/31097279-c1d9edd6-a78c-11e7-9e8a-aef854d363b7.png">
