### PR TITLE
Adding support for ishViewportRange

### DIFF
--- a/config/config.yml.default
+++ b/config/config.yml.default
@@ -43,3 +43,9 @@ defaultPattern: "all"
 
 # show pattern info by default on the "view all" views
 defaultShowPatternInfo: false
+
+# Set a range of viewport widths for S, M, & L buttons
+ishViewportRange:
+  s: [320, 500]
+  m: [500, 800]
+  l: [800, 1200]

--- a/src/PatternLab/Config.php
+++ b/src/PatternLab/Config.php
@@ -245,6 +245,7 @@ class Config {
 		self::setExposedOption("ishFontSize");
 		self::setExposedOption("ishMaximum");
 		self::setExposedOption("ishMinimum");
+		self::setExposedOption("ishViewportRange");
 		self::setExposedOption("outputFileSuffixes");
 		self::setExposedOption("plugins");
 		


### PR DESCRIPTION
This adds support for `ishViewportRange` that was added to the [StyleguideKit v3.5.0](https://github.com/pattern-lab/styleguidekit-assets-default/releases/tag/v3.5.0) by @bmuenzenmeyer 