### PR TITLE
Preventing PHP 7 from being required (for now)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
   "require": {
     "php": ">=5.4",
     "alchemy/zippy": "^0.3",
+    "doctrine/collections": "1.4.0",
     "kevinlebrun/colors.php": "^1.0",
     "michelf/php-markdown": "^1.6",
     "seld/jsonlint": "^1.0",


### PR DESCRIPTION
Locking collections dependency down to 1.4 as zippy had depended on it and when it went to 1.5.0 it required php 7.1 +