### PR TITLE
Allowing Pattern State to be set in MD files front matter. 

### DIFF
--- a/src/PatternLab/PatternData/Rules/DocumentationRule.php
+++ b/src/PatternLab/PatternData/Rules/DocumentationRule.php
@@ -83,7 +83,11 @@ class DocumentationRule extends \PatternLab\PatternData\Rule {
 		if (isset($title)) {
 			$patternStoreData["nameClean"] = $title;
 		}
-		
+
+    if (isset($yaml["state"])) {
+      $patternStoreData["state"] = $yaml["state"];
+    }
+
 		// if the pattern data store already exists make sure this data overwrites it
 		$patternStoreData = (PatternData::checkOption($patternStoreKey)) ? array_replace_recursive(PatternData::getOption($patternStoreKey),$patternStoreData) : $patternStoreData;
 		PatternData::setOption($patternStoreKey, $patternStoreData);


### PR DESCRIPTION
Currently, to set [Pattern State](http://patternlab.io/docs/pattern-states.html) one needs to rename `button.twig` to `button@inprogress.twig`. This change brings the much better approach from the Node version (while keeping the old behavior), that let's one create a file `button.md` that contains:

```
---
state: inprogress
---
```

/cc @sghoweri 