### PR TITLE
Adding to MD docs Yaml meta settings

### DIFF
--- a/src/PatternLab/PatternData/Rules/DocumentationRule.php
+++ b/src/PatternLab/PatternData/Rules/DocumentationRule.php
@@ -80,12 +80,24 @@ class DocumentationRule extends \PatternLab\PatternData\Rule {
 								  "meta"       => $yaml,
 								  "full"       => $doc);
 
+		// can set `title: My Cool Pattern` instead of lifting from file name
 		if (isset($title)) {
 			$patternStoreData["nameClean"] = $title;
 		}
 
-    if (isset($yaml["state"])) {
-      $patternStoreData["state"] = $yaml["state"];
+		$availableKeys = [
+      'state', // can use `state: inprogress` instead of `button@inprogress.mustache`
+      'hidden', // setting to `true`, removes from menu and viewall, which is same as adding `_` prefix
+      'noviewall', // setting to `true`, removes from view alls but keeps in menu, which is same as adding `-` prefix
+      'order', // @todo implement order
+      'tags', // not implemented, awaiting spec approval and integration with styleguide kit. adding to be in sync with Node version.
+      'links', // not implemented, awaiting spec approval and integration with styleguide kit. adding to be in sync with Node version.
+    ];
+
+		foreach ($availableKeys as $key) {
+      if (isset($yaml[$key])) {
+        $patternStoreData[$key] = $yaml[$key];
+      }
     }
 
 		// if the pattern data store already exists make sure this data overwrites it


### PR DESCRIPTION
If you have `button.twig` and `button.md`, these settings are now added: `hidden`, and `noviewall`. That makes it so these are all that can be used:

```
---
title: My cool button
state: inprogress
hidden: true
noviewall: true
---

Notes and description in *markdown*.
```

- `hidden` - same as renaming file to `_button.twig`, which hides it from views all and menu. [Docs here](http://patternlab.io/docs/pattern-hiding.html)
- `noviewall` - same as renaming file to `-button.twig`, which hides from views alls but **not** menu. 

These settings have been added as well:

- `order` - Spec approved and implemented in Node version
- `tags` - Spec not approved, but name is and [is set in Node version](https://github.com/pattern-lab/patternlab-node/blob/3cf5ed4340a2ca0ceb1a7e888864d3d33a03fa52/core/lib/pattern_assembler.js#L173-L194) and not used as well
- `links` - Spec not approved, but name is and [is set in Node version](https://github.com/pattern-lab/patternlab-node/blob/3cf5ed4340a2ca0ceb1a7e888864d3d33a03fa52/core/lib/pattern_assembler.js#L173-L194) and not used as well