### PR TITLE
Preventing state from being added to Patterns in lineage.

### DIFF
--- a/src/PatternLab/PatternData.php
+++ b/src/PatternLab/PatternData.php
@@ -180,17 +180,20 @@ class PatternData {
 		$event = new PatternDataEvent($options);
 		$dispatcherInstance->dispatch("patternData.lineageHelperEnd",$event);
 
+
+		// `PatternStateHelper` is deprecated. It was for adding state to all patterns in the lineage of the pattern with state and that is no longer needed. Commenting out use and deprecating class in case there's a use I haven't figured out.
+
 		// dispatch that the pattern state helper is about to start
-		$event = new PatternDataEvent($options);
-		$dispatcherInstance->dispatch("patternData.patternStateHelperStart",$event);
+//		$event = new PatternDataEvent($options);
+//		$dispatcherInstance->dispatch("patternData.patternStateHelperStart",$event);
 
 		// using the lineage info update the pattern states on PatternData::$store
-		$patternStateHelper      = new PatternStateHelper();
-		$patternStateHelper->run();
+//		$patternStateHelper      = new PatternStateHelper();
+//		$patternStateHelper->run();
 
 		// dispatch that the pattern state helper is ended
-		$event = new PatternDataEvent($options);
-		$dispatcherInstance->dispatch("patternData.patternStateHelperEnd",$event);
+//		$event = new PatternDataEvent($options);
+//		$dispatcherInstance->dispatch("patternData.patternStateHelperEnd",$event);
 
 		// set-up code pattern paths
 		$ppdExporter             = new PatternPathSrcExporter();

--- a/src/PatternLab/PatternData/Helpers/PatternStateHelper.php
+++ b/src/PatternLab/PatternData/Helpers/PatternStateHelper.php
@@ -17,6 +17,11 @@ use \PatternLab\Config;
 use \PatternLab\PatternData;
 use \PatternLab\Timer;
 
+/**
+ * Class PatternStateHelper
+ * @package PatternLab\PatternData\Helpers
+ * @deprecated 3.0.0 It was for adding state to all patterns in the lineage of the pattern with state and that is no longer needed.
+ */
 class PatternStateHelper extends \PatternLab\PatternData\Helper {
 	
 	public function __construct($options = array()) {


### PR DESCRIPTION
Old behavior: if A.twig has a state set and is included in B.twig, then B.twig gets same state.
New behavior: B.twig does not get state from A.twig