### PR TITLE
Implementing Pattern Type (ie atoms) Documentation

### DIFF
--- a/src/PatternLab/PatternData/Exporters/PatternPartialsExporter.php
+++ b/src/PatternLab/PatternData/Exporters/PatternPartialsExporter.php
@@ -101,8 +101,25 @@ class PatternPartialsExporter extends \PatternLab\PatternData\Exporter {
 					$patternPartials[] =  $patternPartialData;
 					
 				}
-				
-			}
+
+      } else if (($patternStoreData["category"] == "pattern") && (isset($patternStoreData["full"]) && ($type === $patternStoreData["full"]))) {
+        // This is for `patternType` docs. Given this structure:
+        // - _patterns/
+        //   - atoms/
+        //     - forms/
+        //   - atoms.md
+        // This will take the contents of `atoms.md` and place at top of "Atoms > View All"
+
+        $patternPartialData = array();
+        // Getting the name from md's `title: My Name` works here, as does the link, but it doesn't make sense to link to the view you are already on. Plus you can just do the title in the MD doc. Keeping here for now in case it's wanted later.
+        // $patternPartialData["patternName"] = isset($patternStoreData["nameClean"]) ? $patternStoreData["nameClean"] : '';
+        // $patternPartialData["patternLink"] = $patternStoreData["full"] . "/index.html";
+
+        $patternPartialData["patternSectionSubtype"] = true;
+        $patternPartialData["patternDesc"] = isset($patternStoreData["desc"]) ? $patternStoreData["desc"] : "";
+
+        $patternPartials[] = $patternPartialData;
+      }
 			
 		}
 		

--- a/src/PatternLab/PatternData/Exporters/PatternPartialsExporter.php
+++ b/src/PatternLab/PatternData/Exporters/PatternPartialsExporter.php
@@ -102,7 +102,7 @@ class PatternPartialsExporter extends \PatternLab\PatternData\Exporter {
 					
 				}
 
-      } else if (($patternStoreData["category"] == "pattern") && (isset($patternStoreData["full"]) && ($type === $patternStoreData["full"]))) {
+      } else if (($patternStoreData["category"] == "pattern") && (isset($patternStoreData["full"]) && ($type === $patternStoreData["full"] || $type === ""))) {
         // This is for `patternType` docs. Given this structure:
         // - _patterns/
         //   - atoms/


### PR DESCRIPTION
This allows MD docs to be added to the top levels, such as Atoms.

Given this structure:

- _patterns/
  - atoms.md
  - atoms/
    - forms.md
    - forms/
       - select.twig

This will take the contents of `atoms.md` and place at top of "Atoms > View All", similar to how `forms.md` is placed at top of "Atoms > Forms > View All".

As @bradfrost said on the Spec discussion:

> As someone who has to re-explain UI component hierarchy over and over again, I'm in favor of this.

I think this will really help teams who have to describe what should be a molecule or organism and other common questions on the high section level.

Spec link: https://github.com/pattern-lab/the-spec/issues/28

/cc @bmuenzenmeyer 