### PR TITLE
bringing back state via lineage

### DIFF
--- a/src/PatternLab/PatternData.php
+++ b/src/PatternLab/PatternData.php
@@ -124,7 +124,11 @@ class PatternData {
 		$patternObjects = iterator_to_array($patternObjects);
 		ksort($patternObjects);
 
-		foreach ($patternObjects as $name => $object) {
+		/**
+     * @var string $name
+     * @var \SplFileInfo $object
+     */
+    foreach ($patternObjects as $name => $object) {
 
 			$ext      = $object->getExtension();
 			$isDir    = $object->isDir();
@@ -181,19 +185,17 @@ class PatternData {
 		$dispatcherInstance->dispatch("patternData.lineageHelperEnd",$event);
 
 
-		// `PatternStateHelper` is deprecated. It was for adding state to all patterns in the lineage of the pattern with state and that is no longer needed. Commenting out use and deprecating class in case there's a use I haven't figured out.
-
 		// dispatch that the pattern state helper is about to start
-//		$event = new PatternDataEvent($options);
-//		$dispatcherInstance->dispatch("patternData.patternStateHelperStart",$event);
+		$event = new PatternDataEvent($options);
+		$dispatcherInstance->dispatch("patternData.patternStateHelperStart",$event);
 
 		// using the lineage info update the pattern states on PatternData::$store
-//		$patternStateHelper      = new PatternStateHelper();
-//		$patternStateHelper->run();
+		$patternStateHelper      = new PatternStateHelper();
+		$patternStateHelper->run();
 
 		// dispatch that the pattern state helper is ended
-//		$event = new PatternDataEvent($options);
-//		$dispatcherInstance->dispatch("patternData.patternStateHelperEnd",$event);
+		$event = new PatternDataEvent($options);
+		$dispatcherInstance->dispatch("patternData.patternStateHelperEnd",$event);
 
 		// set-up code pattern paths
 		$ppdExporter             = new PatternPathSrcExporter();

--- a/src/PatternLab/PatternData/Exporters/PatternPartialsExporter.php
+++ b/src/PatternLab/PatternData/Exporters/PatternPartialsExporter.php
@@ -114,7 +114,13 @@ class PatternPartialsExporter extends \PatternLab\PatternData\Exporter {
 					
 				}
 
-      } else if (($patternStoreData["category"] == "pattern") && $canShow && (isset($patternStoreData["full"]) && ($type === $patternStoreData["full"] || $type === ""))) {
+      } else if (
+          ($patternStoreData["category"] == "pattern")
+          && $canShow
+          && (isset($patternStoreData["full"])
+          && ($type === $patternStoreData["full"] || $type === ""))
+          && ($subtype === "")
+      ) {
         // This is for `patternType` docs. Given this structure:
         // - _patterns/
         //   - atoms/

--- a/src/PatternLab/PatternData/Helpers/PatternStateHelper.php
+++ b/src/PatternLab/PatternData/Helpers/PatternStateHelper.php
@@ -20,7 +20,6 @@ use \PatternLab\Timer;
 /**
  * Class PatternStateHelper
  * @package PatternLab\PatternData\Helpers
- * @deprecated 3.0.0 It was for adding state to all patterns in the lineage of the pattern with state and that is no longer needed.
  */
 class PatternStateHelper extends \PatternLab\PatternData\Helper {
 	


### PR DESCRIPTION
This reverts https://github.com/pattern-lab/patternlab-php-core/pull/139 and allows state to be assigned to patterns that have state in their lineages. I realized that the original bugs were from state assigned to *all* items that use includes... which is from lineage being broken then, which is fixed now: though will require a new RegEx in their config:

```
lineageMatch: >-
  {%([ ]+)?(?:include|extends|embed)(
  |\()[&quot;\&#039;]([\/.@A-Za-z0-9-_]+)[&quot;\&#039;]([\s\S+]*?)%}
```