### PR TITLE
Exposing `theme` and `patternStates` to Styleguidekit

### DIFF
--- a/src/PatternLab/Config.php
+++ b/src/PatternLab/Config.php
@@ -248,6 +248,8 @@ class Config {
 		self::setExposedOption("ishMinimum");
 		self::setExposedOption("ishViewportRange");
 		self::setExposedOption("outputFileSuffixes");
+		self::setExposedOption("patternStates");
+		self::setExposedOption("theme");
 		self::setExposedOption("plugins");
 		
 	}


### PR DESCRIPTION
This is just an under the hood tweak to help future Styleguide kit development.

Relates to: https://github.com/pattern-lab/styleguidekit-assets-default/issues/75