### PR TITLE
Removing defaults for ishViewportRange

### DIFF
--- a/config/config.yml.default
+++ b/config/config.yml.default
@@ -43,9 +43,3 @@ defaultPattern: "all"
 
 # show pattern info by default on the "view all" views
 defaultShowPatternInfo: false
-
-# Set a range of viewport widths for S, M, & L buttons
-ishViewportRange:
-  s: [320, 500]
-  m: [500, 800]
-  l: [800, 1200]


### PR DESCRIPTION
So it doesn't unexpectedly limit viewport range.

Relates to : 

- https://github.com/pattern-lab/patternlab-php-core/pull/131
- https://github.com/pattern-lab/styleguidekit-assets-default/pull/99