### PR TITLE
More Helpful JSON / YAML Error Messages + Minor cleanup of JSON / YAML related variables in Pattern Rules

### DIFF
--- a/src/PatternLab/PatternData/Rules/PatternInfoRule.php
+++ b/src/PatternLab/PatternData/Rules/PatternInfoRule.php
@@ -46,19 +46,20 @@ class PatternInfoRule extends \PatternLab\PatternData\Rule {
 		
 		$patternStoreData = array("category" => "pattern");
 		
-		$file = file_get_contents(Config::getOption("patternSourceDir")."/".$pathName);
+		$filePath = Config::getOption("patternSourceDir")."/".$pathName;
+		$file = file_get_contents($filePath);
 		
 		if ($ext == "json") {
 			$data = json_decode($file,true);
 			if ($jsonErrorMessage = JSON::hasError()) {
-				JSON::lastErrorMsg($name,$jsonErrorMessage,$data);
+				JSON::lastErrorMsg($filePath,$jsonErrorMessage,$data);
 			}
 		} else {
 			
 			try {
 				$data = YAML::parse($file);
 			} catch (ParseException $e) {
-				printf("unable to parse ".$pathNameClean.": %s..\n", $e->getMessage());
+				printf("unable to parse ".$filePath.": %s..\n", $e->getMessage());
 			}
 			
 			// single line of text won't throw a YAML error. returns as string

--- a/src/PatternLab/PatternData/Rules/PseudoPatternRule.php
+++ b/src/PatternLab/PatternData/Rules/PseudoPatternRule.php
@@ -120,55 +120,57 @@ class PseudoPatternRule extends \PatternLab\PatternData\Rule {
 			$patternStoreData["breadcrumb"]  = array("patternType" => $patternTypeClean, "patternSubtype" => $patternSubtypeClean);
 		}
 
-		$patternDataBase = array();
-		if (file_exists(Config::getOption("patternSourceDir").DIRECTORY_SEPARATOR.$path.DIRECTORY_SEPARATOR.$patternBaseData)) {
-			$data = file_get_contents(Config::getOption("patternSourceDir").DIRECTORY_SEPARATOR.$path.DIRECTORY_SEPARATOR.$patternBaseData);
+		$patternBaseData = array();
+		$patternBaseFilePath = Config::getOption("patternSourceDir").DIRECTORY_SEPARATOR.$path.DIRECTORY_SEPARATOR.$patternBaseData;
+
+		if (file_exists($patternBaseFilePath)) {
+			$patternBaseData = file_get_contents($patternBaseFilePath);
 			if ($ext == "json") {
-				$patternDataBase = json_decode($data,true);
+				$patternBaseData = json_decode($patternBaseData,true);
 				if ($jsonErrorMessage = JSON::hasError()) {
-					JSON::lastErrorMsg($patternBaseJSON,$jsonErrorMessage,$data);
+					JSON::lastErrorMsg($patternBaseFilePath,$jsonErrorMessage,$patternBaseData);
 				}
 			} else {
 
 				try {
-					$patternDataBase = YAML::parse($data);
+					$patternBaseData = YAML::parse($patternBaseData);
 				} catch (ParseException $e) {
-					printf("unable to parse ".$pathNameClean.": %s..\n", $e->getMessage());
+					printf("unable to parse ".$patternBaseFilePath.": %s..\n", $e->getMessage());
 				}
 
 				// single line of text won't throw a YAML error. returns as string
-				if (gettype($patternDataBase) == "string") {
-					$patternDataBase = array();
+				if (gettype($patternBaseData) == "string") {
+					$patternBaseData = array();
 				}
-
 			}
-
 		}
 
 		// get the data for the pseudo-pattern
-		$data = file_get_contents(Config::getOption("patternSourceDir").DIRECTORY_SEPARATOR.$pathName);
+		$patternPsuedoFilePath = Config::getOption("patternSourceDir").DIRECTORY_SEPARATOR.$pathName;
+		$patternPsuedoData = file_get_contents($patternPsuedoFilePath);
+
 		if ($ext == "json") {
-			$patternData = json_decode($data,true);
+			$patternPsuedoData = json_decode($patternPsuedoData,true);
 			if ($jsonErrorMessage = JSON::hasError()) {
-				JSON::lastErrorMsg($name,$jsonErrorMessage,$data);
+				JSON::lastErrorMsg($patternPsuedoFilePath,$jsonErrorMessage,$patternPsuedoData);
 			}
 		} else {
 
 			try {
-				$patternData = YAML::parse($data);
+				$patternPsuedoData = YAML::parse($patternPsuedoData);
 			} catch (ParseException $e) {
-				printf("unable to parse ".$pathNameClean.": %s..\n", $e->getMessage());
+				printf("unable to parse ".$patternPsuedoFilePath.": %s..\n", $e->getMessage());
 			}
 
 			// single line of text won't throw a YAML error. returns as string
-			if (gettype($patternData) == "string") {
-				$patternData = array();
+			if (gettype($patternPsuedoData) == "string") {
+				$patternPsuedoData = array();
 			}
 
 		}
 
 		// make sure the pattern data is an array before merging the data
-		$patternStoreData["data"] = is_array($patternData) ? array_replace_recursive($patternDataBase, $patternData) : $patternDataBase;
+		$patternStoreData["data"] = is_array($patternPsuedoData) ? array_replace_recursive($patternBaseData, $patternPsuedoData) : $patternBaseData;
 
 		// if the pattern data store already exists make sure it is merged and overwrites this data
     if (PatternData::checkOption($patternStoreKey)) {


### PR DESCRIPTION
Now passing in the actual filename + path to the JSON and YAML file functions so errors are more helpful + easier to debug.

This small change makes a huge difference in projects like the Bolt Design System I run (where we're installing, versioning and publishing individual components) given that Pattern Lab by default tries to pick up deeply nested files in our component-specific `node_modules` folders which, unless / until patched, can often cause fatal errors w/ Pattern Lab that are close to near impossible to track down otherwise.

<img width="834" alt="better_json_errors_-_before" src="https://user-images.githubusercontent.com/1617209/32137335-c49055a6-bbeb-11e7-9f1f-d657d31ebab6.png">

<img width="837" alt="better_json_errors_-_after" src="https://user-images.githubusercontent.com/1617209/32137337-cad98c2a-bbeb-11e7-9070-3002969c3e8a.png">

CC @aleksip 

