### PR TITLE
Reorder Patterns, Folders in Pattern Lab Nav Based On `Order` Config

### DIFF
--- a/src/PatternLab/PatternData.php
+++ b/src/PatternLab/PatternData.php
@@ -233,55 +233,6 @@ class PatternData {
 
 	}
 
-
-	/**
-	* Compare two sections of data in order to calculate pattern ordering 
-	*/
-	public static function recursive_sort(array &$data) {
-		$has_key = FALSE;
-		foreach ($data as $value) {
-			if (isset($value['order'])) {
-				$has_key = TRUE;
-				break;
-			}
-		}
-	  
-		if ($has_key) {
-			usort($data, [__CLASS__, 'compareData']);
-		}
-	  
-		foreach ($data as $key => $value) {
-			if (is_array($value)) {
-				self::recursive_sort($data[$key]);
-			}
-		}
-		
-		return $data;
-	}
-	
-
-	/**
-	* Compare two sections of data in order to calculate pattern ordering 
-	*/
-	public static function compareData($a, $b) {
-		if (isset($a['order']) && isset($b['order'])){
-			return ($a['order'] < $b['order']) ? -1 : 1;
-		} else {
-			return 0;
-		}
-	}
-
-
-	/**
-	* Recursively sort the global patternData based on the key provided
-	* ex. $sortedData = PatternData::sortPatternData($data, 'order');
-	*/
-	public static function sortPatternData(array $data) {
-		$result = self::recursive_sort($data);
-		return $result;
-	}
-
-
 	/**
 	* Get the directory separator
 	*/
@@ -290,7 +241,7 @@ class PatternData {
 	}
 
 	/**
-	* GEt the front meta bits (hidden and noviewall)
+	* Get the front meta bits (hidden and noviewall)
 	*/
 	public static function getFrontMeta() {
 		return self::$frontMeta;

--- a/src/PatternLab/PatternData.php
+++ b/src/PatternLab/PatternData.php
@@ -34,6 +34,7 @@ class PatternData {
 	protected static $patternSubtypeDash  = "";
 	protected static $patternSubtypeSet   = false;
 	protected static $patternType         = "";
+	protected static $defaultPatternOrder = 0;
 	protected static $patternTypeClean    = "";
 	protected static $patternTypeDash     = "";
 	protected static $rules               = array();
@@ -232,6 +233,55 @@ class PatternData {
 
 	}
 
+
+	/**
+	* Compare two sections of data in order to calculate pattern ordering 
+	*/
+	public static function recursive_sort(array &$data) {
+		$has_key = FALSE;
+		foreach ($data as $value) {
+			if (isset($value['order'])) {
+				$has_key = TRUE;
+				break;
+			}
+		}
+	  
+		if ($has_key) {
+			usort($data, [__CLASS__, 'compareData']);
+		}
+	  
+		foreach ($data as $key => $value) {
+			if (is_array($value)) {
+				self::recursive_sort($data[$key]);
+			}
+		}
+		
+		return $data;
+	}
+	
+
+	/**
+	* Compare two sections of data in order to calculate pattern ordering 
+	*/
+	public static function compareData($a, $b) {
+		if (isset($a['order']) && isset($b['order'])){
+			return ($a['order'] < $b['order']) ? -1 : 1;
+		} else {
+			return 0;
+		}
+	}
+
+
+	/**
+	* Recursively sort the global patternData based on the key provided
+	* ex. $sortedData = PatternData::sortPatternData($data, 'order');
+	*/
+	public static function sortPatternData(array $data) {
+		$result = self::recursive_sort($data);
+		return $result;
+	}
+
+
 	/**
 	* Get the directory separator
 	*/
@@ -328,6 +378,18 @@ class PatternData {
 		return false;
 
 	}
+
+
+	/**
+	* Get the pattern order if it exists, otherwise return default
+	*/
+	public static function getPatternOrder() {
+		if (isset(self::$patternOrder)) {
+			return self::$patternOrder;
+		}
+		return self::$defaultPatternOrder;
+	}
+
 
 	/**
 	* Get the pattern type
@@ -543,6 +605,16 @@ class PatternData {
 		self::$patternType = $optionValue;
 
 	}
+
+
+	/**
+	* Set the pattern order value
+	* @param  {String}       the order value
+	*/
+	public static function setPatternOrder($optionValue) {
+		self::$patternOrder = $optionValue;
+	}
+
 
 	/**
 	* Set the pattern type clean

--- a/src/PatternLab/PatternData/Exporters/NavItemsExporter.php
+++ b/src/PatternLab/PatternData/Exporters/NavItemsExporter.php
@@ -27,8 +27,21 @@ class NavItemsExporter extends \PatternLab\PatternData\Exporter {
 		
 		$this->store = PatternData::get();
 		$this->styleGuideExcludes = Config::getOption("styleGuideExcludes");
-		
 	}
+
+
+	// Sort navigation level based on the `order` key (if it exists)
+	private function sortNavByOrder($a, $b) {
+		if (!isset($a['order'])){
+			return 0;
+		} else if (!isset($b['order'])){
+			return 0;
+		} else if ($a['order'] == $b['order']){
+			return 0;
+		}
+		return ($a['order'] < $b['order']) ? -1 : 1;
+	}
+
 	
 	public function run() {
 		
@@ -46,7 +59,7 @@ class NavItemsExporter extends \PatternLab\PatternData\Exporter {
 		foreach ($this->store as $patternStoreKey => $patternStoreData) {
 			
 			if ($patternStoreData["category"] == "patternType") {
-				
+
 				$bi = (count($navItems["patternTypes"]) == 0) ? 0 : $bi + 1;
 				
 				// add a new patternType to the nav
@@ -98,11 +111,8 @@ class NavItemsExporter extends \PatternLab\PatternData\Exporter {
 					} else {
 						$navItems["patternTypes"][$bi]["patternTypeItems"][$ni]["patternSubtypeItems"][] = $patternInfo;
 					}
-					
 				}
-				
 			}
-			
 		}
 		
 		// review each subtype. add a view all link or remove the subtype as necessary
@@ -157,13 +167,26 @@ class NavItemsExporter extends \PatternLab\PatternData\Exporter {
 																					 "patternPartial" => "viewall-".$patternTypeDash."-all");
 				
 			}
-			
 		}
-		
-		$navItems = PatternData::sortPatternData($navItems);
-	
+
+
+		// Sort the navItems by order property before returning final navigation (@TODO: look into possibly moving the sortNavByOrder function to a more global (ie. reusable) place)
+		foreach ($navItems as $navItem) {
+			// Sort top level patternTypes (ex. 01-atoms)
+			usort($navItems['patternTypes'], array( $this, 'sortNavByOrder' ) ); 
+			
+			foreach ($navItem as $patternTypeKey => $patternTypeValue) {
+				// Then sort patternTypeItems and/or patternItems depending on what exists (ex. Homepage or Buttons)
+				usort($navItems['patternTypes'][$patternTypeKey]['patternTypeItems'], array( $this, 'sortNavByOrder' ) ); 
+				usort($navItems['patternTypes'][$patternTypeKey]['patternItems'], array( $this, 'sortNavByOrder' ) );
+
+				// Finallly, finish sorting out the nested patternSubtypeItems (Primary Button, etc)
+				for($i = 0, $c = count($navItems['patternTypes'][$patternTypeKey]['patternTypeItems']); $i < $c; $i++){
+					usort($navItems['patternTypes'][$patternTypeKey]['patternTypeItems'][$i]['patternSubtypeItems'], array( $this, 'sortNavByOrder' ) );
+				}
+			}
+		}
+
 		return $navItems;
-		
 	}
-	
 }

--- a/src/PatternLab/PatternData/Exporters/NavItemsExporter.php
+++ b/src/PatternLab/PatternData/Exporters/NavItemsExporter.php
@@ -54,6 +54,7 @@ class NavItemsExporter extends \PatternLab\PatternData\Exporter {
 													   "patternTypeUC"    => ucwords($patternStoreData["nameClean"]),
 													   "patternType"      => $patternStoreData["name"],
 													   "patternTypeDash"  => $patternStoreData["nameDash"],
+													   "order"            => $patternStoreData["order"],
 													   "patternTypeItems" => array(),
 													   "patternItems"     => array());
 				
@@ -71,6 +72,7 @@ class NavItemsExporter extends \PatternLab\PatternData\Exporter {
 																				"patternSubtypeUC"    => ucwords($patternStoreData["nameClean"]),
 																				"patternSubtype"      => $patternStoreData["name"],
 																				"patternSubtypeDash"  => $patternStoreData["nameDash"],
+																				"order"               => $patternStoreData["order"],
 																				"patternSubtypeItems" => array());
 				
 				// starting a new set of pattern types. it might not have any pattern subtypes
@@ -87,6 +89,7 @@ class NavItemsExporter extends \PatternLab\PatternData\Exporter {
 										 "patternSrcPath" => $patternStoreData["pathName"],
 										 "patternName"    => ucwords($patternStoreData["nameClean"]),
 										 "patternState"   => $patternStoreData["state"],
+										 "order"          => $patternStoreData["order"],
 										 "patternPartial" => $patternStoreData["partial"]);
 					
 					// add to the nav
@@ -157,6 +160,8 @@ class NavItemsExporter extends \PatternLab\PatternData\Exporter {
 			
 		}
 		
+		$navItems = PatternData::sortPatternData($navItems);
+	
 		return $navItems;
 		
 	}

--- a/src/PatternLab/PatternData/Rules/PatternRule.php
+++ b/src/PatternLab/PatternData/Rules/PatternRule.php
@@ -42,6 +42,7 @@ class PatternRule extends \PatternLab\PatternData\Rule {
 		$patternTypeDash     = PatternData::getPatternTypeDash();
 		$dirSep              = PatternData::getDirSep();
 		$frontMeta           = PatternData::getFrontMeta();
+		$patternOrder        = PatternData::getPatternOrder();
 		
 		// should this pattern get rendered?
 		$hidden           = ($name[0] == "_");
@@ -83,6 +84,7 @@ class PatternRule extends \PatternLab\PatternData\Rule {
 								  "noviewall"        => $noviewall,
 								  "depth"            => $depth,
 								  "ext"              => $ext,
+								  "order"            => $patternOrder, // default pattern order
 								  "path"             => $path,
 								  "pathName"         => $patternPath,
 								  "pathDash"         => $patternPathDash,

--- a/src/PatternLab/PatternData/Rules/PatternSubtypeRule.php
+++ b/src/PatternLab/PatternData/Rules/PatternSubtypeRule.php
@@ -37,7 +37,8 @@ class PatternSubtypeRule extends \PatternLab\PatternData\Rule {
 		$patternTypeDash        = PatternData::getPatternTypeDash();
 		$patternTypeClean       = PatternData::getPatternTypeClean();
 		$dirSep                 = PatternData::getDirSep();
-		
+		$patternOrder           = PatternData::getPatternOrder();
+
 		// set-up the names
 		$patternSubtype         = $name;                                        // 02-blocks
 		$patternSubtypeDash     = $this->getPatternName($name,false);           // blocks
@@ -61,6 +62,7 @@ class PatternSubtypeRule extends \PatternLab\PatternData\Rule {
 										"breadcrumb" => array("patternType" => $patternTypeClean),
 										"depth"      => $depth,
 										"ext"        => $ext,
+										"order"      => $patternOrder,
 										"path"       => $path,
 										"pathName"   => $patternSubtypePath,
 										"pathDash"   => $patternSubtypePathDash,

--- a/src/PatternLab/PatternData/Rules/PatternTypeRule.php
+++ b/src/PatternLab/PatternData/Rules/PatternTypeRule.php
@@ -34,6 +34,7 @@ class PatternTypeRule extends \PatternLab\PatternData\Rule {
 		
 		// load default vars
 		$dirSep              = PatternData::getDirSep();
+		$patternOrder        = PatternData::getPatternOrder();
 		
 		// set-up the names
 		$patternType         = $name;                                        // 00-atoms
@@ -53,6 +54,7 @@ class PatternTypeRule extends \PatternLab\PatternData\Rule {
 							 "nameClean" => $patternTypeClean,
 							 "depth"     => $depth,
 							 "ext"       => $ext,
+							 "order"     => $patternOrder,
 							 "path"      => $path,
 							 "pathName"  => $patternTypePath,
 							 "pathDash"  => $patternTypePathDash,

--- a/src/PatternLab/PatternData/Rules/PseudoPatternRule.php
+++ b/src/PatternLab/PatternData/Rules/PseudoPatternRule.php
@@ -86,6 +86,8 @@ class PseudoPatternRule extends \PatternLab\PatternData\Rule {
 			$patternPathOrigDash = str_replace($dirSep,"-",$patternPathOrig);                   // 04-pages-00-homepage
 		}
 
+		// Use the original pattern's order value by default if we can find it
+		$patternOrder = !empty(PatternData::getPatternOption($patternBaseOrig,"order")) ? PatternData::getPatternOption($patternBaseOrig,"order") : PatternData::getPatternOrder();
 		// create a key for the data store
 		$patternStoreKey     = $patternPartial;
 
@@ -103,6 +105,7 @@ class PseudoPatternRule extends \PatternLab\PatternData\Rule {
 									"noviewall"    => $noviewall,
 									"depth"        => $depth,
 									"ext"          => $ext,
+									"order"        => $patternOrder,
 									"path"         => $path,
 									"pathName"     => $patternPath,
 									"pathDash"     => $patternPathDash,


### PR DESCRIPTION
Specifically, allow Pattern Lab users to manually adjust the visual ordering of any navigation items in the Pattern Lab main menu based on the configurable `order` property that's set in a pattern's config file (ie. a corresponding pattern markdown file with the `order` key set.) -- without needing to make any physical filename / folder name changes or prefixes.

Ex. given a fonts.twig file, the default `0` zero order value could get overwritten (pushed up or down the list) in the cooresponding `fonts.md` file:
```
---
order: 4
---
```

This PR also updates all top level Pattern Types, Pattern SubTypes, Patterns, & Pattern Items top inherit a default order value set in case a manually-entered value isn't set.

In short, this PR tries to take a crack at attempting to address the bulk of the use cases and details mentioned in #138 without having to go too far off the deep end for this one. Oh - and this also manages to get top level Pattern Types to be configurable now via markdown files as well! =)

Author's sidenote(s):
1. This PR covers the across the board data updates needed to let us set an order property (with an inherited default), updates to the Documentation rule so top level Pattern Types can be sorted via markdown files, and the sorting of Pattern Types, Pattern SubTypes, Pattern Items, and Pattern SubTypeItems in the top level Pattern Lab dropdown navigation **but** this PR does _NOT_ unfortunately cover reordering the styleguide / viewall ordering as well (just yet). Way too much work already had to go into this so I figure to get this up here first so we can iterate vs having this get help up too much.

2. I had originally tried (and failed) to reorder everything at the central pattern data $store however I inevitably ran into major issues with getting things to render correctly and consistently (if at all) so this implementation tackles reordering "downstream" when the final data structure is getting ready to be exported (ie. exported as the top level navigation).  This might be something to take another look into down the road, or by someone who speaks PHP as a first language...

### Example test w/ Order Output for Debugging
> Configuring the `Organisms` top level Pattern Type order to -1, `Buttons` and `Images` Pattern SubTypes to 2 and 10, and nested Animations and Fonts patterns to -1 and 4 respectfully. Huzzah! 
<img width="545" alt="pattern_lab_-_all" src="https://user-images.githubusercontent.com/1617209/32152093-251c2870-bcf8-11e7-85b2-c5827ca3a91e.png">

CC @bradfrost @aleksip @christophersmith262