### PR TITLE
Option for disabling keyboard-input and use sensible defaults from the config-file.

### DIFF
--- a/src/PatternLab/InstallerUtil.php
+++ b/src/PatternLab/InstallerUtil.php
@@ -483,7 +483,15 @@ class InstallerUtil {
 			}
 			
 			if ($prompt) {
-				
+			    
+
+				$existing_paths_policy = Config::getOption("existingPathsPolicy");
+				if ($existing_paths_policy == 'merge') {
+					return false;
+				}
+				else if ($existing_paths_policy == 'replace') {
+					return true;
+				}
 				// prompt for input using the supplied query
 				$prompt  = "the path <path>".$humanReadablePath."</path> already exists. merge or replace with the contents of <path>".$packageName."</path> package?";
 				$options = "M/r";


### PR DESCRIPTION
We are using a CI to deploy our websites. As part of the deployment process we want to build patternlab by running `cd <patternlab-folder> && composer install && php core/console --generate`. This is currently not possible, as patternlab requires that you press some keys when installing it.

To fix this I added a new config-option called `existingPathsPolicy`, where you can setup how patternlab should react. 

So for a keyless installation of patternlab, all you need to do is to add these two lines to your `config/config.yml`-file:

```
overrideConfig: a
existingPathsPolicy: merge
```