### PR TITLE
Update zippy library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
   },
   "require": {
     "php": ">=5.4",
-    "alchemy/zippy": "^0.3",
+    "alchemy/zippy": "^0.4",
     "doctrine/collections": "1.4.0",
     "kevinlebrun/colors.php": "^1.0",
     "michelf/php-markdown": "^1.6",


### PR DESCRIPTION
Fix #118 starter kit fails with invalid options on newer versions tar.

Re-open #121 since it was never merged.