### PR TITLE
Don't replace underscores in markdown documentation file names

### DIFF
--- a/src/PatternLab/PatternData/Rules/DocumentationRule.php
+++ b/src/PatternLab/PatternData/Rules/DocumentationRule.php
@@ -40,8 +40,8 @@ class DocumentationRule extends \PatternLab\PatternData\Rule {
 		$dirSep             = PatternData::getDirSep();
 		
 		// set-up the names, $name == 00-colors.md
-		$doc        = str_replace(".".$this->extProp,"",$name);              // 00-colors
-		$docDash    = $this->getPatternName(str_replace("_","",$doc),false); // colors
+		$doc        = str_replace(".".$this->extProp,"",$name); // 00-colors
+		$docDash    = $this->getPatternName($doc);              // colors
 		$docPartial = $patternTypeDash."-".$docDash;
 		
 		// default vars


### PR DESCRIPTION
If a pattern name includes an underscore, the corresponding markdown documentation name is mangled by removing the underscore, preventing the documentation from being correctly connected to the pattern.

There was an unresolved comment on this behaviour already: https://github.com/pattern-lab/patternlab-php-core/commit/1eccd08e0ac68b5053d2ab92b53c5f6f4153866e#r21397132