### PR TITLE
Stop exceptions from breaking the watcher

### DIFF
--- a/src/PatternLab/Watcher.php
+++ b/src/PatternLab/Watcher.php
@@ -321,7 +321,15 @@ class Watcher extends Builder {
 		Annotations::clear();
 		
 		$g = new Generator();
-		$g->generate($options);
+		try {
+			$g->generate($options);
+		} catch (\Exception $e) {
+			Console::writeWarning("Failed on update to ".$fileName);
+			Console::writeWarning($e->getMessage());
+		} catch (\Throwable $e) {
+			Console::writeWarning("Failed on update to ".$fileName);
+			Console::writeWarning($e->getMessage());
+		}
 		
 	}
 	


### PR DESCRIPTION
We're currently hitting https://github.com/pattern-lab/patternengine-php-twig/issues/34#issuecomment-383032335, where an invalid Twig template (possible while developing) breaks the watcher. Using `--no-procs` reveals the exception and the terminated process, otherwise it silently fails (the watch process continues, but nothing happens).

This catches any exception and outputs the message.