### PR TITLE
Composer Dependency Conflict: PHP 8 compatibility 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   "require": {
     "php": ">=5.4",
     "alchemy/zippy": "^0.3",
-    "doctrine/collections": "1.4.0",
+    "doctrine/collections": "^1.4.0",
     "kevinlebrun/colors.php": "^1.0",
     "michelf/php-markdown": "^1.6",
     "seld/jsonlint": "^1.0",


### PR DESCRIPTION
The composer package `doctrine/collections` needs to be allowed to upgrade to `^1.6.5` for [php 8 compatibility](https://github.com/doctrine/collections/releases/tag/1.6.5).